### PR TITLE
Update of multipole kick to follow PTC dipole errors logic 

### DIFF
--- a/src/madl_track.mad
+++ b/src/madl_track.mad
@@ -494,18 +494,18 @@ local function thin_kick_track(elem, m, l) -- l == 0
     by  = byt
   end
 
-  m.px = px - dirch*by + dirch*knl[1]
-  m.py = py + dirch*bx - dirch*ksl[1]
+  m.px = px - dirch*by + dirch*elem.knl[1]
+  m.py = py + dirch*bx - dirch*elem.ksl[1]
   
   if knl[1] ~= 0 or ksl[1] ~= 0 then
     local t, pt in m
     local beta_inv = 1/m.beam.beta
     local pz = sqrt(1 + 2*beta_inv*pt + pt^2)
     if lrad ~=0 then -- dipole focusing and deltap
-      m.px = m.px - knl[1]*knl[1]*x/lrad + dirch*knl[1]*(pz -1)
-      m.py = m.py - ksl[1]*ksl[1]*y/lrad + dirch*ksl[1]*(pz -1)
+      m.px = m.px - elem.knl[1]*elem.knl[1]*x/lrad + dirch*elem.knl[1]*(pz -1)
+      m.py = m.py - elem.ksl[1]*elem.ksl[1]*y/lrad + dirch*elem.ksl[1]*(pz -1)
     end  
-    m.t = t + dirch*(knl[1]*x - ksl[1]*y) * (beta_inv+pt)/pz
+    m.t = t + dirch*(elem.knl[1]*x - elem.ksl[1]*y) * (beta_inv+pt)/pz
   end
 
   m.out_action(elem, m, l, 'thin_kick_track')


### PR DESCRIPTION
Update of multipole kick to follow PTC dipole errors logic (the way how dipole errors are taken into account in case of thin multipole). It's different from MAD-X track!