### PR TITLE
Fix inconsistencies with string interpolation

### DIFF
--- a/src/madl_gutil.mad
+++ b/src/madl_gutil.mad
@@ -425,7 +425,11 @@ local function interp_fun (tbl, tag)
     end
   end
   local num = tonumber(key) -- cases $n or ${n}
-  return (tbl[num or key] or tag) .. e
+  local val = tbl[num or key]
+  if val == nil then
+    error(string.format("Undefined key: %q", '$'..tag))
+  end
+  return val .. e
 end
 
 function utility.strinterp(str, var)

--- a/src/madl_gutil.mad
+++ b/src/madl_gutil.mad
@@ -417,13 +417,15 @@ end
 -- string interpolation
 
 local function interp_fun (tbl, tag)
-  if tag:sub(1,1) == '$' then return tag end
-  local key, e = tag, ''
-  if key:sub(-1,-1) == '}' then
-    if key:sub(1,1) == '{'
-    then key    = key:sub(2, -2)      -- remove {}
-    else key, e = key:sub(1, -2), '}' -- remove  }
-    end
+  local s, e = tag:sub(1,1), tag:sub(-1, -1)
+  local key, suffix = tag, ''
+  if s == '$' then return tag end
+  if s == '{' and e == '}' then
+    key         = key:sub(2, -2)
+  elseif s ~= '{' and e == '}' then
+    key, suffix = key:sub(1, -2), '}'
+  elseif s == '{' and e ~= '}' then
+    error(string.format("Unclosed brace: %q", '$'..tag))
   end
   if key == '' then
     error(string.format("Missing key: %q", '$'..tag))
@@ -433,7 +435,7 @@ local function interp_fun (tbl, tag)
   if val == nil then
     error(string.format("Undefined key: %q", '$'..tag))
   end
-  return val .. e
+  return val .. suffix
 end
 
 function utility.strinterp(str, var)

--- a/src/madl_gutil.mad
+++ b/src/madl_gutil.mad
@@ -435,7 +435,7 @@ local function interp_fun (tbl, tag)
   if val == nil then
     error(string.format("Undefined key: %q", '$'..tag))
   end
-  return val .. suffix
+  return tostring_(val) .. suffix
 end
 
 function utility.strinterp(str, var)

--- a/src/madl_gutil.mad
+++ b/src/madl_gutil.mad
@@ -439,12 +439,12 @@ local function interp_fun (tbl, tag)
 end
 
 function utility.strinterp(str, var)
-  if is_nil(var) then return str end
-  if is_table(var) then
-    local bind1st in MAD.gfunc
-    str = str:gsub('%$([{%$]?[%w_]*}?)', bind1st(interp_fun, var))
+  local bind1st in MAD.gfunc
+  -- FIXME: handle cdata, remove typecheck altogether (duck typing)?
+  if not is_table(var) then
+    error("invalid argument #2 (table expected)")
   end
-  return str
+  return str:gsub('%$([{%$]?[%w_]*}?)', bind1st(interp_fun, var))
 end
 
 string.interp          = utility.strinterp

--- a/src/madl_gutil.mad
+++ b/src/madl_gutil.mad
@@ -417,12 +417,16 @@ end
 -- string interpolation
 
 local function interp_fun (tbl, tag)
+  if tag:sub(1,1) == '$' then return tag end
   local key, e = tag, ''
   if key:sub(-1,-1) == '}' then
     if key:sub(1,1) == '{'
     then key    = key:sub(2, -2)      -- remove {}
     else key, e = key:sub(1, -2), '}' -- remove  }
     end
+  end
+  if key == '' then
+    error(string.format("Missing key: %q", '$'..tag))
   end
   local num = tonumber(key) -- cases $n or ${n}
   local val = tbl[num or key]
@@ -436,7 +440,7 @@ function utility.strinterp(str, var)
   if is_nil(var) then return str end
   if is_table(var) then
     local bind1st in MAD.gfunc
-    str = str:gsub('%$({?[%w_]+}?)', bind1st(interp_fun, var))
+    str = str:gsub('%$([{%$]?[%w_]*}?)', bind1st(interp_fun, var))
   end
   return str
 end

--- a/tests/utests/gutil.mad
+++ b/tests/utests/gutil.mad
@@ -533,4 +533,24 @@ function TestUtils:testToTable()
   assertAlmostEquals ( t[5]/10000 - 1, 0, 4*eps )
 end
 
+function TestUtils:testStrInterp()
+  -- basic tests:
+  assertEquals("$2 $3 $1" % {4, 5, 6},    "5 6 4" )
+  assertEquals("$foo"     % {foo="bar"},  "bar"   )
+  assertEquals("${foo}"   % {foo="bar"},  "bar"   )
+  assertEquals("${2}"     % {0, 1},       "1"     )
+  assertEquals("{$foo}"   % {foo="bar"},  "{bar}" )
+
+  -- handles sparse tables:
+  assertEquals("$1"       % {[1]=0},      "0"     )
+  assertEquals("$2"       % {[2]=1},      "1"     )   -- #{[2]=1}   = 0
+  assertEquals("$3"       % {[3]=2},      "2"     )   -- #{[3]=2}   = 0
+  assertEquals("$3"       % {0,nil,2},    "2"     )   -- #{0,nil,2) = 1
+
+  -- undefined keys:
+  assertErrorMsgContains("Undefined key", \"$1"    % {})
+  assertErrorMsgContains("Undefined key", \"$foo"  % {})
+  assertErrorMsgContains("Undefined key", \"$foo}" % {})
+end
+
 -- end ------------------------------------------------------------------------o

--- a/tests/utests/gutil.mad
+++ b/tests/utests/gutil.mad
@@ -82,6 +82,15 @@ local function assertTypes (tkey, tfunc, tskip, ...)
   end
 end
 
+function TestUtils:setUp()
+  self.saved_format = option.format
+end
+
+function TestUtils:tearDown()
+  -- clean up after failed tests:
+  option.format = self.saved_format
+end
+
 function TestUtils:testBtst()
   for i=0,31 do
     assertTrue( btst(0xffffffff, i) )
@@ -507,7 +516,6 @@ function TestUtils:testSame()
 end
 
 function TestUtils:testToString()
-  local format in option -- save
   option.format = '%.10f'
   assertEquals ( tostring(1/3 ), '0.3333333333')
   assertEquals ( tostring(1/3i), '0.0000000000-0.3333333333i')
@@ -517,7 +525,6 @@ function TestUtils:testToString()
   option.format = '%-2.4e'
   assertEquals ( tostring(1/(0.5+3i)), '5.4054e-02-3.2432e-01i')
   assertEquals ( tostring(0.5+ 1/3i ), '5.0000e-01-3.3333e-01i')
-  option.format = format
 end
 
 function TestUtils:testToTable()
@@ -540,6 +547,14 @@ function TestUtils:testStrInterp()
   assertEquals("${foo}"   % {foo="bar"},  "bar"   )
   assertEquals("${2}"     % {0, 1},       "1"     )
   assertEquals("{$foo}"   % {foo="bar"},  "{bar}" )
+  assertEquals("$T"       % {T=true},     "true"  )
+  assertEquals("$F"       % {F=false},    "false" )
+
+  -- can control format:
+  option.format = '%+.2e'
+  assertEquals("$num"     % {num=1.23e4}, "+1.23e+04")
+  -- cancel side effects on following tests:
+  option.format = self.saved_format
 
   -- handles sparse tables:
   assertEquals("$1"       % {[1]=0},      "0"     )

--- a/tests/utests/gutil.mad
+++ b/tests/utests/gutil.mad
@@ -552,6 +552,12 @@ function TestUtils:testStrInterp()
   assertEquals("$$foo"    % {},           "$foo"  )
   assertEquals("$$foo"    % {foo="bar"},  "$foo"  )
 
+  -- invalid argument:
+  assertError(\ "$foo" % nil                      )
+  assertError(\ "$foo" % 0                        )
+  assertError(\ ""     % nil                      )
+  assertError(\ ""     % 0                        )
+
   -- no '$' without key:
   local tricky = {['']='A', ['{']='B', ['}']='C', ['{foo']='D', ['foo}']='E'}
   assertError(\"${}"      % tricky                )

--- a/tests/utests/gutil.mad
+++ b/tests/utests/gutil.mad
@@ -553,10 +553,12 @@ function TestUtils:testStrInterp()
   assertEquals("$$foo"    % {foo="bar"},  "$foo"  )
 
   -- no '$' without key:
-  assertError(\"${}"      % {}                    )
-  assertError(\"${"       % {}                    )
-  assertError(\"$"        % {}                    )
-  assertError(\"$"        % {[''] = '$'}          )
+  local tricky = {['']='A', ['{']='B', ['}']='C', ['{foo']='D', ['foo}']='E'}
+  assertError(\"${}"      % tricky                )
+  assertError(\"$"        % tricky                )
+  assertError(\"$}"       % tricky                )
+  assertErrorMsgContains("Unclosed brace", \"${"    % tricky)
+  assertErrorMsgContains("Unclosed brace", \"${foo" % tricky)
 
   -- undefined keys:
   assertErrorMsgContains("Undefined key", \"$1"    % {})

--- a/tests/utests/gutil.mad
+++ b/tests/utests/gutil.mad
@@ -24,7 +24,7 @@
 -- locals ---------------------------------------------------------------------o
 
 local assertNil, assertNotNil, assertTrue, assertFalse, assertEquals,
-      assertAlmostEquals, assertErrorMsgContains in MAD.utest
+      assertAlmostEquals, assertErrorMsgContains, assertError in MAD.utest
 
 local compose                           in MAD.gfunc
 local pi, log, eps                      in MAD.gmath
@@ -546,6 +546,17 @@ function TestUtils:testStrInterp()
   assertEquals("$2"       % {[2]=1},      "1"     )   -- #{[2]=1}   = 0
   assertEquals("$3"       % {[3]=2},      "2"     )   -- #{[3]=2}   = 0
   assertEquals("$3"       % {0,nil,2},    "2"     )   -- #{0,nil,2) = 1
+
+  -- dollar insertion:
+  assertEquals("$$"       % {},           "$"     )
+  assertEquals("$$foo"    % {},           "$foo"  )
+  assertEquals("$$foo"    % {foo="bar"},  "$foo"  )
+
+  -- no '$' without key:
+  assertError(\"${}"      % {}                    )
+  assertError(\"${"       % {}                    )
+  assertError(\"$"        % {}                    )
+  assertError(\"$"        % {[''] = '$'}          )
 
   -- undefined keys:
   assertErrorMsgContains("Undefined key", \"$1"    % {})


### PR DESCRIPTION
Hey,

fixes a few issues + inconsistent behaviour with the string interpolation function which renders it useless for me. The most severe one is that falsy values are silently ignored and interpolated with the key name instead, this leads to several inconsistent/unexpected behaviours.


Example:

```lua
p = \s,t print(s, '->', select(2, pcall(\ s % t)))

p("$foo" ,  nil             )
p("$foo" ,  {}              )

p("$$"   ,  {}              )
p('$$foo',  {}              )
p('$$foo',  {foo="bar"}     )

p("${foo",  {}              )
p("${foo",  {['{foo']="bar"})

p("$foo}",  {}              )
p("$foo}",  {foo="bar"}     )

p('$foo' ,  {foo=true}      )
p('$foo' ,  {foo=false}     )
```

Before:

```
$foo	->	$foo
$foo	->	foo

$$	->	$$
$$foo	->	$foo
$$foo	->	$bar

${foo	->	{foo
${foo	->	bar

$foo}	->	foo}}
$foo}	->	bar}

$foo	->	./src/madl_gutil.mad:428: attempt to concatenate local 'tag' (a boolean value)
$foo	->	foo
```


After:

```
$foo	->	./src/madl_gutil.mad:445: invalid argument #2 (table expected)
$foo	->	./src/madl_gutil.mad:436: Undefined key: "$foo"

$$	->	$
$$foo	->	$foo
$$foo	->	$foo

${foo	->	./src/madl_gutil.mad:428: Unclosed brace: "${foo"
${foo	->	./src/madl_gutil.mad:428: Unclosed brace: "${foo"

$foo}	->	./src/madl_gutil.mad:436: Undefined key: "$foo}"
$foo}	->	bar}

$foo	->	true
$foo	->	false
```

See commit messages for more details.
