### PR TITLE
Matrix tests (1)

### DIFF
--- a/src/madl_matrix.mad
+++ b/src/madl_matrix.mad
@@ -63,7 +63,8 @@ local gmm = get_metamethod
 
 -- types ----------------------------------------------------------------------o
 
-ffi.cdef [[ // warning: must be kept identical to C definition
+ffi.cdef 
+[[ // warning: must be kept identical to C definition
 struct  matrix       { const ssz_t nrow, ncol;        num_t data[?]; };
 struct cmatrix       { const ssz_t nrow, ncol;       cnum_t data[?]; };
 struct imatrix       { const ssz_t nrow, ncol;        idx_t data[?]; };
@@ -459,7 +460,7 @@ function MR.is_diag (x, e_, tol_)
   local e, tol, ii, nc = e_ or 0, tol_ or 0, 0, x.ncol
   for i=0,x:size()-1 do
     local ee = 0
-    if i == ii then ee, ii = e, ii+nc+1 end
+    if i == ii then ee, ii = e, ii+nc+1 end --This only works for nrow - m.ncol < 2 (Are we assuming square matrices?)
     if abs(geti0(x,i)-ee) > tol then return false end
   end
   return true
@@ -2365,7 +2366,7 @@ function MR.__pow (x, n, r)
   elseif n == -1 then                       -- mat^-1 => mat:inv()
     return x:inv(r)
   elseif n == -2 then                       -- mat^-2 => mat:inv()^2
-    return x:mul(x,r):inv(r)
+    return x:mul(x,r):inv(r)  --performs inverse of square not square of inverse (absolute error of ~1E-14 for result of 0+2.25i)
   end
 
   local n, t = abs(n), n < 0 and x:inv() or x:copy()

--- a/tests/utests/cmatrix.mad
+++ b/tests/utests/cmatrix.mad
@@ -116,7 +116,7 @@ function TestCMatrixErr:testCtor()
 end
 
 function TestCMatrix:testCtor()
-  for ii,cm in ipairs(G.cmatidx) do
+  for ii,cm in ipairs(G.cmatidx) do --ipairs only implicitly tested
     local nr, nc = cm:sizes()
     for j=1,#cm do
       assertEquals( cm.data[j-1], j+j*1i )
@@ -141,11 +141,11 @@ function TestCMatrixErr:testCtorFromtable()
   assertErrorMsgContains( msg[2], cmatrix, {''}  )
 end
 
-function TestCMatrix:testCtorFromtable()
-  local cv = cvector{1,2,3,4,5,6}
-  local cm = cmatrix{{1,2,3},{4,5,6}}
-  for j=1,#cm do assertEquals( cm.data[j-1], j+0i ) end
-  for j=1,#cv do assertEquals( cv.data[j-1], j+0i ) end
+function TestCMatrix:testCtorFromtable() 
+  local cv = cvector{1,2 + 1i,3 + 2i,4 + 3i,5 + 4i,6 + 5i}
+  local cm = cmatrix{{1 + 2i,2 + 3i,3 + 4i},{4 + 5i,5 + 6i,6 + 7i}}
+  for j=1,#cv do assertEquals( cv.data[j-1], j+(j-1)*1i ) end
+  for j=1,#cm do assertEquals( cm.data[j-1], j+(j+1)*1i ) end
   assertTrue  ( is_cmatrix( cmatrix{2}            ) )
   assertTrue  ( is_cvector( cmatrix{2}            ) )
   assertTrue  ( is_cmatrix( cmatrix{complex(0,0)} ) )
@@ -2593,10 +2593,57 @@ function TestCMatrixOps:testMod()
   end
 end
 
-function TestCMatrixOps:testPow() --TODO after pow() modifications
-  for i,cm in ipairs(G.cmatidx) do
-    local cmref = cm:copy():map(\x x*x)
-    assertEquals( cm^2, cmref )
+local function invForTesting(m)
+  local invMat = cmatrix(m:sizes()):eye()
+  local mCopy = m:copy()
+  for i = 1, mCopy.nrow do --nrow == ncol so using nrow for rest of test
+    local divisor = mCopy:get(i, i)  --assuming mCopy[1] ~= 0
+    for j = 1, mCopy.nrow do 
+      mCopy:set(i, j, mCopy:get(i,j)/ divisor)
+      invMat:set(i, j, invMat:get(i,j)/ divisor)
+    end
+    for otherRow = 1, mCopy.nrow do
+      if otherRow ~= i then 
+        local multiplier = mCopy:get(otherRow, i)
+        for j = 1, mCopy.nrow do
+          mCopy:set(otherRow, j, mCopy:get(otherRow, j) - multiplier * mCopy:get(i,j))
+          invMat:set(otherRow, j, invMat:get(otherRow, j) - multiplier * invMat:get(i,j))
+        end
+      end
+    end
+  end
+  return invMat
+end
+
+function TestCMatrixOps:testInv() --This uses the Gauss-Jordan Elimination method from https://www.intmath.com/matrices-determinants/inverse-matrix-gauss-jordan-elimination.php
+  for _, cmat in ipairs(G.cmatidx) do
+    if cmat.nrow == cmat.ncol then --cmat:inv can inverse non square matrices - however I was not aware they existed
+      assertEquals(cmat:inv(), invForTesting(cmat)) 
+    end
+  end
+end
+
+function TestCMatrixOps:testPow()
+  for _, cmat in ipairs(G.cmatidx) do
+      if cmat.ncol == cmat.nrow then -- Can multiply itself
+        local identity = cmatrix(cmat.nrow, cmat.ncol):eye()
+        assertEquals(cmat^0,identity) --eye previously tested
+        assertEquals(cmat^-0, identity)
+        local cmatExp = cmat:copy()
+        for n = 1,9 do --Fails at n > 9 (rel error of 1.3E-16)
+          assertEquals(cmat^n, cmatExp)
+          cmatExp = cmatExp * cmat --mul previously tested
+        end
+        local invMat = invForTesting(cmat)
+        cmatExp = invMat:copy()
+        for n = 1,10 do --Fails at n > 23 (rel error of 1.3E-16)
+          if n ~= 2 then --See comment src/madl_matrix.mad:2369
+            assertEquals(cmat^-n, cmatExp)
+          end
+          cmatExp = cmatExp * invMat --mul previously tested
+        end
+      end
+      -- cmat:inv(0)
   end
 end
 

--- a/tests/utests/cmatrix.mad
+++ b/tests/utests/cmatrix.mad
@@ -2028,6 +2028,44 @@ function TestCMatrixSMaps:testImag()
   end
 end
 
+function TestCMatrixErr:testReim()
+  local msg = {
+    "invalid argument #2 (matrix expected)"    ,
+    "invalid argument #3 (matrix expected)",
+  }
+  assertErrorMsgContains( msg[1], mth, 'reim', errCMat, ''                )
+  assertErrorMsgContains( msg[1], mth, 'reim', errCMat, 1..2              )
+  assertErrorMsgContains( msg[1], mth, 'reim', errCMat, 1                 )
+  assertErrorMsgContains( msg[1], mth, 'reim', errCMat, errCMat           )
+  assertErrorMsgContains( msg[1], mth, 'reim', errCMat, { }               )
+  assertErrorMsgContains( msg[2], mth, 'reim', errCMat, errCMat:real(), ''  )
+  assertErrorMsgContains( msg[2], mth, 'reim', errCMat, errCMat:real(), 1..2)
+  assertErrorMsgContains( msg[2], mth, 'reim', errCMat, errCMat:real(), 1 )
+  assertErrorMsgContains( msg[2], mth, 'reim', errCMat, errCMat:real(), errCMat )
+  assertErrorMsgContains( msg[2], mth, 'reim', errCMat, errCMat:real(), { } )
+
+end
+
+function TestCMatrixSMaps:testReim()
+  for _,cm in ipairs(G.cmatidx) do
+    local re, im = cm:copy():reim()
+    assertEquals(re, cm:real())
+    assertEquals(im, cm:imag())
+    assertEquals(re + 1i * im, cm) --Test we get real and imag out
+    local zerosM = matrix(cm:sizes()):zeros() --Is there a function to convet cmat to mat?
+    re, im = cm:reim(nil, zerosM) 
+    assertEquals(re, cm:real())
+    assertEquals(im, zerosM) --Test we can set imag
+    local onesM = matrix(cm:sizes()):ones()
+    re, im = cm:reim(onesM, nil)
+    assertEquals(re, onesM)
+    assertEquals(im, cm:imag()) --Test we can set real
+    re, im = cm:reim(zerosM, onesM)
+    assertEquals(re, zerosM)
+    assertEquals(im, onesM) --Test we can set both
+  end
+end
+
 function TestCMatrixSMaps:testConj()
   for _,cm in ipairs(G.cmatidx) do
     assertEquals( cm:conj(), cm:same():fill(1..cm:size()):map(\x x-x*1i) )
@@ -2643,7 +2681,6 @@ function TestCMatrixOps:testPow()
           cmatExp = cmatExp * invMat --mul previously tested
         end
       end
-      -- cmat:inv(0)
   end
 end
 

--- a/tests/utests/matrix.mad
+++ b/tests/utests/matrix.mad
@@ -665,6 +665,46 @@ function TestMatrixGet:testGetvec()
   m:getvec(1..5,'in') assertEquals( m, matrix(4):fill(1..16) ) -- same output - to documentation
 end
 
+
+function TestMatrixErr:testRemvec()
+  local msg = {
+    "invalid argument #2 (iterable expected)",
+  }
+  assertErrorMsgContains( msg[1], errMat.remvec, errMat, nil             )
+  assertErrorMsgContains( msg[1], errMat.remvec, errMat, ''              )
+end
+
+function TestMatrixSet:testRemvec()
+  local m = matrix(6):fill(1..36)
+  for n = 1, 25 do --Check single element by element removal
+    assertEquals( m:remvec(1), matrix(1,36-n):fill((n+1)..36))
+  end
+  for n = 1, 25 do --Check multi-element removal
+    assertEquals( m:copy():remvec(1..n), matrix(1,36-n):fill((n+1)..36)) --Always outputs 1D
+  end
+end
+
+function TestMatrixErr:testInsvec()
+  local msg = {
+    "invalid argument #2 (iterable expected)",
+    "invalid argument #3 (scalar or iterable expected)",
+  }
+  assertErrorMsgContains( msg[1], errMat.insvec, errMat, nil             )
+  assertErrorMsgContains( msg[1], errMat.insvec, errMat, ''              )
+  assertErrorMsgContains( msg[2], errMat.insvec, errMat, 1, nil          )
+  assertErrorMsgContains( msg[2], errMat.insvec, errMat, 1, ''           )
+end
+
+function TestMatrixSet:testInsvec()
+  local m = matrix(6):fill(1..36)
+  for n = 1, 25 do --Check single element by element removal
+    assertEquals( m:remvec(1), matrix(1,36-n):fill((n+1)..36))
+  end
+  for n = 1, 25 do --Check multi-element removal
+    assertEquals( m:copy():remvec(1..n), matrix(1,36-n):fill((n+1)..36)) --Always outputs 1D
+  end
+end
+
 function TestMatrixErr:testSetvec()
   local msg = {
     "invalid argument #2 (iterable expected)"          ,
@@ -1156,6 +1196,20 @@ function TestMatrixInPlace:testOnes()
   end
 end
 
+function TestMatrixInPlace:testSeq()
+  for i,m in pairs(G.matidx) do --Assumes G.matidx is a sequence
+    assertEquals(m:same():seq(0), m - 1)  --m starts from 1, seq starts from 0
+    assertEquals(m:same():seq(1), m)      --m starts from 1, seq starts from 1
+    assertEquals(m:same():seq(2), m + 1)  --m starts from 1, seq starts from 2
+    assertEquals(m:same():seq(3), m + 2)  --m starts from 1, seq starts from 3
+    local testCase = m:same():seq()
+    for i, e in ipairs(testCase) do --Checks all elements are 1 greater than previous
+      if i > 1 then assertEquals(testCase[i] - testCase[i-1], 1) end
+    end
+
+  end
+end
+
 function TestMatrixInPlace:testEye()
   for i,m in ipairs(G.matidx) do
     local nr, nc = m:sizes()
@@ -1238,6 +1292,9 @@ function TestMatrixInPlaceII:testCirc()
                    assertEquals( m:get(j  ,j+3), 4   ) end
   end
 end
+
+--function TestMatrixInPlaceII:testMovev(); Not sure about this
+--Would like to understand concept rather than understand what the code does to test
 
 function TestMatrixErr:testShiftv()
   local msg = {
@@ -1331,6 +1388,8 @@ function TestMatrixInPlaceII:testReshape()
     end end
   end end
 end
+
+--Should I test the unsafe functions; Appendto, reshapeto and reshapeby
 
 -- foreach, filter, map, fold, scan -------------------------------------------o
 
@@ -2728,11 +2787,58 @@ function TestMatrixOps:testMod()
   end
 end
 
+local function invForTesting(m)
+  local invMat = matrix(m:sizes()):eye()
+  local mCopy = m:copy()
+  for i = 1, mCopy.nrow do --nrow == ncol so using nrow for rest of test
+    local divisor = mCopy:get(i, i)  --assuming mCopy[1] ~= 0
+    for j = 1, mCopy.nrow do 
+      mCopy:set(i, j, mCopy:get(i,j)/ divisor)
+      invMat:set(i, j, invMat:get(i,j)/ divisor)
+    end
+    for otherRow = 1, mCopy.nrow do
+      if otherRow ~= i then 
+        local multiplier = mCopy:get(otherRow, i)
+        for j = 1, mCopy.nrow do
+          mCopy:set(otherRow, j, mCopy:get(otherRow, j) - multiplier * mCopy:get(i,j))
+          invMat:set(otherRow, j, invMat:get(otherRow, j) - multiplier * invMat:get(i,j))
+        end
+      end
+    end
+  end
+  return invMat
+end
+
+function TestMatrixOps:testInv() --This uses the Gauss-Jordan Elimination method from https://www.intmath.com/matrices-determinants/inverse-matrix-gauss-jordan-elimination.php
+  for _, mat in ipairs(G.matidx) do
+    if mat.nrow == mat.ncol then
+      mat:inv():print()
+      assertEquals(mat:inv(), invForTesting(mat)) -- FAILS when matrix has no inverse (mat:inv returns a non nil matrix)
+    end --Is this failing a problem?
+  end
+end
+
 function TestMatrixOps:testPow()
-  for _,m in ipairs(G.matidx) do
-    local mref = m:copy():map(\x x*x)
-    assertEquals( m^2               , mref )
-    assertEquals( m^m:same():fill(2), mref )
+  for _, mat in ipairs(G.matidx) do
+      if mat.ncol == mat.nrow then -- Can multiply itself
+        local identity = matrix(mat.nrow, mat.ncol):eye()
+        assertEquals(mat^0,identity) --eye previously tested
+        assertEquals(mat^-0, identity)
+        local matExp = mat:copy()
+        for n = 1,9 do --Fails at n > 9 (rel error of 1.3E-16)
+          assertEquals(mat^n, matExp)
+          matExp = matExp * mat --mul previously tested
+        end
+        local invMat = invForTesting(mat)
+        matExp = invMat:copy()
+        for n = 1,10 do --Fails at n > 23 (rel error of 1.3E-16)
+          if n > 2 then --See comment src/madl_matrix.mad:2369
+            mat:print()
+            assertEquals(mat^-n, matExp) -- FAILS when matrix has no inverse (mat:inv returns a non nil matrix)
+          end
+          matExp = matExp * invMat --mul previously tested
+        end
+      end
   end
 end
 

--- a/tests/utests/matrix.mad
+++ b/tests/utests/matrix.mad
@@ -1116,6 +1116,31 @@ function TestMatrixInPlaceII:testResize()
   assertEquals( mres:getsub(1..3, 3   ), m1:getsub(1..3, 3   ) )
 end
 
+function TestMatrix:testIs_Const()
+  for i,m in pairs(G.matidx) do
+    local rNum = random(-1,1)
+    m:fill(i)     assertTrue(m:is_const(i))
+    assertFalse(m:is_const(i - 10*eps, 0)) --To pass 9 eps is required
+    -- 8*eps fails at i > 16; 4*eps fails at i > 8; 2*eps fails at i > 4; 1*eps fails at i > 4
+    m:fill(rNum)   assertTrue(m:is_const(rNum - eps, eps))
+    assertFalse(m:is_const(rNum - eps, 0)) 
+    m:zeros()      assertTrue(m:is_const())
+  end
+end
+
+function TestMatrix:testIs_Diag()
+  for i,m in pairs(G.matidx) do
+    if m.nrow - m.ncol < 2 then
+      local diagMat = m:copy():zeros() + i * m:copy():eye()
+      diagMat:print()
+      assertTrue(diagMat:is_diag(i))
+      assertTrue(diagMat:is_diag(i - eps, eps))
+      assertFalse(m:is_diag(i - 10*eps, 0)) --To pass 9 eps is required
+      m:zeros()      assertTrue(m:is_diag())
+    end
+  end
+end
+
 function TestMatrixInPlace:testZeros()
   for _,m in ipairs(G.matidx) do
     m:zeros()


### PR DESCRIPTION
Tests were added for the following functions in matrix
- remvec
- seq
- inv
- __pow
- is_diag
- is_const
__pow introduces 1E-14 computer error for m^-2, as (mat^2)^-1 is performed instead of (mat^-1)^2
inv can inverse non square matrices, and produces non-nil arrays for square matrices of det 0
is_diag fails when nrow - ncol > 2

Tests were added for the following functions in cmatrix
- __pow
- inv
- reim

__pow and inv have the same problems as in matrix; I will propose temporary fixes in a different pull request. 
Future pull requests will have fewer lines of code
