### PR TITLE
Matrix Tests (5)

### DIFF
--- a/tests/utests/matrix.mad
+++ b/tests/utests/matrix.mad
@@ -1968,6 +1968,24 @@ function TestMatrixSMaps:testAbs()
   end
 end
 
+function TestMatrixSMaps:testSign()
+  for _,m in ipairs(G.mattmp) do
+    local r = nrange(-3, 3, m:size())
+    m:fill(r):sign('in')
+    local res = m:copy():map(\x => return (x > 0 and 1 or 0) - (x < 0 and 1 or 0) end, m:same())
+    assertEquals( m, res)
+  end
+end
+
+function TestMatrixSMaps:testSign1()
+  for _,m in ipairs(G.mattmp) do
+    local r = nrange(-3, 3, m:size())
+    m:fill(r):sign1('in')
+    local res = m:copy():map(\x => return (x >= 0 and 1 or 0) - (x <= -0 and 1 or 0) end, m:same())
+    assertEquals( m, res)
+  end
+end
+
 function TestMatrixSMaps:testSqrt()
   for _,m in ipairs(G.matidx) do
     local mn = m:size()
@@ -2026,6 +2044,14 @@ function TestMatrixSMaps:testTan()
   end
 end
 
+function TestMatrixSMaps:testCot()
+  for _,m in ipairs(G.mattmp) do
+    local r = nrange(1,pi/2,m:size())
+    m:fill(r)
+    assertTrue( m:cot():eq( m:copy():map(\x cos(x)/sin(x)), eps ) )
+  end
+end
+
 function TestMatrixSMaps:testSinh()
   for _,m in ipairs(G.mattmp) do
     local r = nrange(1,pi/2,m:size())
@@ -2047,6 +2073,14 @@ function TestMatrixSMaps:testTanh()
     local r = nrange(1,pi/2,m:size())
     m:fill(r)
     assertTrue( m:tanh():eq( m:copy():map(\x sinh(x)/cosh(x)), eps) )
+  end
+end
+
+function TestMatrixSMaps:testCoth()
+  for _,m in ipairs(G.mattmp) do
+    local r = nrange(1,pi/2,m:size())
+    m:fill(r)
+    assertTrue( m:coth():eq( m:copy():map(\x cosh(x)/sinh(x)), 2*eps) )
   end
 end
 
@@ -2074,6 +2108,14 @@ function TestMatrixSMaps:testAtan()
   end
 end
 
+function TestMatrixSMaps:testAcot()
+  for _,m in ipairs(G.mattmp) do
+    local r = nrange(1,pi/2,m:size())
+    m:fill(r)
+    assertTrue( m:cot():acot('in'):eq( m:same():fill(r), eps ) )
+  end
+end
+
 function TestMatrixSMaps:testAsinh()
   for _,m in ipairs(G.mattmp) do
     local r = nrange(1,pi/2,m:size())
@@ -2095,6 +2137,14 @@ function TestMatrixSMaps:testAtanh()
     local r = nrange(1,pi/2,m:size())
     m:fill(r)
     assertTrue( m:tanh():atanh('in'):eq( m:copy(), 2*eps ) )
+  end
+end
+
+function TestMatrixSMaps:testAcoth()
+  for _,m in ipairs(G.mattmp) do
+    local r = nrange(1,pi/2,m:size())
+    m:fill(r)
+    assertTrue( m:coth():acoth('in'):eq( m:copy(), 4*eps ) )
   end
 end
 


### PR DESCRIPTION
Added tests for the maps of sign, sign1, cot, coth, acot and acoth; copying the format of other TestMatrixSMaps