### PR TITLE
Cmatrix Tests (3)

### DIFF
--- a/tests/utests/cmatrix.mad
+++ b/tests/utests/cmatrix.mad
@@ -2319,6 +2319,37 @@ end
 function TestCMatrixErr:testSymplectify() end
 function TestCMatrixSympl:testSymplectify() end
 
+-- mean, variance, horners method --------------------------------------------o
+function TestCMatrix:testMean()
+  for _,cm in ipairs(G.cmatidx) do
+    assertEquals( cm:mean(), cm:sum()/cm:size() )
+  end
+end
+
+function TestCMatrix:testVariance() --This fails as the function variance actually returns the standard deviation, is this intentional? See line 102 in mad_vec.c
+  for _,cm in ipairs(G.cmatidx) do
+    local mean = cm:mean()
+    local sum = 0
+    for _, val in ipairs(cm) do 
+      sum = sum + (val - mean)^2
+    end
+    assertEquals( cm:variance(), sum / cm:size() )
+  end
+end
+
+function TestCMatrix:testEval() --Algorthm adapted from www.geeksforgeeks.org/horners-method-algorithm/
+  for _,cm in ipairs(G.cmatidx) do
+    for _, x0 in ipairs({1 + 1i,2 + 2i,3 + 3i,4 + 4i,5 + 5i}) do
+      local result = cm[cm:size()]
+      for i = cm:size()-1, 1, -1 do
+        result = result *x0 + cm[i]
+      end
+      assertEquals(cm:eval(x0), result)
+    end
+  end
+end
+
+
 -- conjugate, transpose -------------------------------------------------------o
 
 function TestCMatrixLinAlg:testConjugate()


### PR DESCRIPTION
Added tests for mean, variance and eval
All the tests fail due to problems in madl_matrix.mad; the next pull request will include fixes
Including the fixes, the variance test fails as it calculates standard deviation, such as in the real matrix case.