### PR TITLE
Foreach Matrix Test Fixes

### DIFF
--- a/tests/utests/cmatrix.mad
+++ b/tests/utests/cmatrix.mad
@@ -1679,23 +1679,13 @@ function TestCMatrixFun:testForeach()
     local t = {}
     local f = \x, ij => t[ij] = x  end
     cm:foreach(f)
-    assertEquals(t, cm:totable())                          --Check function call
-
-    cm:foreach("+", t)
-    assertEquals(t, cm:add(cm:same():seq()):totable())                   --Check function call w/ r and f is opstring
+    assertEquals(t, cm:totable())                                           --Check function call
     
-    f = \x, ij -> x + 2*ij
     t = cmatrix(math.ceil(#cm/2), 1)
-    cm:foreach(1..math.ceil(#cm/2), f, t)   
+    f = \x, ij => t[ij] = x + 2*ij end
+    cm:foreach(1..math.ceil(#cm/2), f)   
     assertEquals(#t, math.ceil(#cm/2))
-    assertEquals(t, cm:add(cm:same():seq()*2):getvec(1..math.ceil(#cm/2)))  --Check function call w/ ij and r as mat
-
-    f = \x, ij -> x * x
-    cm:foreach(f, "in")                                    
-    assertEquals(cm:copy():foreach(f, "in"), cm:epow(2))    --Check function call w/ r = "in"
-
-    cm:foreach(1..#cm, "*", "in")                                    
-    assertEquals(cm:copy():foreach(f, "in"), cm:epow(2))    --Check function call w/ r = "in" and ij and f is opstring
+    assertEquals(t, cm:add(cm:same():seq()*2):getvec(1..math.ceil(#cm/2)))  --Check function call w/ ij
   end
 end
 

--- a/tests/utests/matrix.mad
+++ b/tests/utests/matrix.mad
@@ -1893,23 +1893,13 @@ function TestMatrixFun:testForeach()
     local t = {}
     local f = \x, ij => t[ij] = x  end
     m:foreach(f)
-    assertEquals(t, m:totable())                          --Check function call
-
-    m:foreach("+", t)
-    assertEquals(t, m:mul(2):totable())                   --Check function call w/ r and f is opstring
+    assertEquals(t, m:totable())                                         --Check function call
     
-    f = \x, ij -> x + 2*ij
-    t = matrix(math.ceil(#m/2), 1)
-    m:foreach(1..math.ceil(#m/2), f, t)   
+    t = cmatrix(math.ceil(#m/2), 1)
+    f = \x, ij => t[ij] = x + 2*ij end
+    m:foreach(1..math.ceil(#m/2), f)   
     assertEquals(#t, math.ceil(#m/2))
-    assertEquals(t, m:mul(3):getvec(1..math.ceil(#m/2)))  --Check function call w/ ij and r as mat
-
-    f = \x, ij -> x * x
-    m:foreach(f, "in")                                    
-    assertEquals(m:copy():foreach(f, "in"), m:epow(2))    --Check function call w/ r = "in"
-
-    m:foreach(1..#m, "*", "in")                                    
-    assertEquals(m:copy():foreach(f, "in"), m:epow(2))    --Check function call w/ r = "in" and ij and f is opstring
+    assertEquals(t, m:add(m:same():seq()*2):getvec(1..math.ceil(#m/2)))  --Check function call w/ ij
   end
 end
 


### PR DESCRIPTION
Fixed matrix and cmatrix foreach tests, now only testing for function call and ij, as other parts of function has been reduced