### PR TITLE
Matrix Test improvements

### DIFF
--- a/src/madl_pymad.mad
+++ b/src/madl_pymad.mad
@@ -229,6 +229,7 @@ local recv_ctpa = \s   -> recv_gtpsa(s,    recv_cnum)
 local function send_tbl (self, t)
   local nxt, dat, ini, n = kpairs(t)
   send_bool(self, not rawequal(nxt(dat,ini),nil))
+  n = n or 0
   send_int (self, n)
   for i=1,n do self:send(t[i]) end -- deep copy
   return self
@@ -248,9 +249,7 @@ local function chktbl (a)
 end
 
 local send_ref = \s -> s
-local recv_ref = \s -> assert(s._env[recv_str(s)], "reference not found")
-local recv_ref = \s -> assert(load(recv_str(s),nil,nil,s._env), "reference not found")()
-
+local recv_ref = \s -> assert(load(recv_str(s), nil, nil, s._env), "reference not found")()
 -- dispatch tables ------------------------------------------------------------o
 
 local type_fun = {

--- a/tests/utests/matrix.mad
+++ b/tests/utests/matrix.mad
@@ -761,14 +761,33 @@ function TestMatrixErr:testRemvec()
 end
 
 function TestMatrixSet:testRemvec()
-  local m = matrix(6):fill(1..36)
-  for n = 1, 25 do --Check single element by element removal
-    assertEquals( m:remvec(1), matrix(36-n, 1):fill((n+1)..36)) --Now reshaped as column vector
-  end
-  local m = matrix(6):fill(1..36)
-  for n = 1, 25 do --Check multi-element removal
-    assertEquals( m:copy():remvec(1..n), matrix(36-n, 1):fill((n+1)..36)) --Always outputs 1D
-    assertEquals( #m:copy():remvec(1..n), #m - #(1..n) )
+  for _, m in ipairs(G.matidx) do 
+    if #m > 1 then 
+      for remVal = 1, #m do --Single element removal
+        local mc = m:copy()
+        mc:remvec(remVal)
+        assertEquals(#mc, #m-1)
+        for ij = 1, #mc do
+          if     ij < remVal then assertEquals(mc[ij], m[ij  ])
+          elseif ij > remVal then assertEquals(mc[ij], m[ij+1]) 
+          end
+        end
+      end
+      for i = 1, #m do    --Multi element removal
+        for j = i, #m do
+          if i ~= 1 and j ~= #m then --Not the entire matrix
+            local mc = m:copy()
+            mc:remvec(i..j)
+            assertEquals(#mc, #m-(j-i+1))
+            for ij = 1, #mc do
+              if     ij < i then assertEquals(mc[ij], m[ij    ])
+              elseif ij > j then assertEquals(mc[ij], m[ij+j-i+1]) 
+              end
+            end
+          end
+        end
+      end
+    end 
   end
 end
 
@@ -1567,7 +1586,7 @@ function TestMatrixInPlaceII:testCopy()
   end
 end
 
-function TestMatrixInPlaceII:testRemsub() --Need to test for ir or jc = nil
+function TestMatrixInPlaceII:testRemsub() --Need to test for ir or jc = nil (is remcol and remrow sufficient?)
   for _,m in ipairs(G.matidx) do
     local nrow, ncol = m:sizes()
     for startRem = 1, nrow - 1 do 
@@ -1599,13 +1618,30 @@ function TestMatrixInPlaceII:testRemcol()
   for _,m in ipairs(G.matidx) do
     local nrow, ncol = m:sizes()
     if ncol > 1 then
-      local smallMat = m:copy():remcol(1)
-      assertEquals(ncol, smallMat.ncol + 1)
-      local smallMat2 = m:copy():remcol(ncol)
-      for i = 1, nrow do
-        for j = 1, ncol - 1 do 
-          assertEquals(m:get(i, j+1), smallMat:get(i, j)) 
-          assertEquals(m:get(i, j  ), smallMat2:get(i, j))
+      for colToRem = 1, ncol do 
+        local smallMat = m:copy():remcol(colToRem)
+        assertEquals(ncol, smallMat.ncol + 1)
+        for i = 1, nrow do
+          for j = 1, ncol - 1 do 
+            if     j < colToRem then assertEquals(smallMat:get(i, j), m:get(i, j  ))
+            elseif j > colToRem then assertEquals(smallMat:get(i, j), m:get(i, j+1)) 
+            end
+          end
+        end
+      end
+      for remStart = 1, ncol do 
+        for remEnd = remStart, ncol do 
+          if remStart ~= 1 and remEnd ~= ncol then
+            local smallMat = m:copy():remcol(remStart..remEnd)
+            assertEquals(smallMat.ncol, ncol - (remEnd-remStart+1))
+            for i = 1, nrow do
+              for j = 1, smallMat.ncol do 
+                if     j < remStart then assertEquals(smallMat:get(i, j), m:get(i, j                    ))
+                elseif j > remEnd   then assertEquals(smallMat:get(i, j), m:get(i, j+(remEnd-remStart+1))) 
+                end
+              end
+            end
+          end
         end
       end
     end
@@ -1616,13 +1652,30 @@ function TestMatrixInPlaceII:testRemrow()
   for _,m in ipairs(G.matidx) do
     local nrow, ncol = m:sizes()
     if nrow > 1 then
-      local smallMat = m:copy():remrow(1)
-      assertEquals(nrow, smallMat.nrow + 1)
-      local smallMat2 = m:copy():remrow(nrow)
-      for i = 1, nrow - 1 do
-        for j = 1, ncol do 
-          assertEquals(m:get(i+1,j), smallMat:get(i, j))
-          assertEquals(m:get(i  ,j), smallMat2:get(i, j))
+      for rowToRem = 1, nrow do 
+        local smallMat = m:copy():remrow(rowToRem)
+        assertEquals(nrow, smallMat.nrow + 1)
+        for i = 1, nrow - 1 do
+          for j = 1, ncol do 
+            if     i < rowToRem then assertEquals(smallMat:get(i, j), m:get(i  , j))
+            elseif i > rowToRem then assertEquals(smallMat:get(i, j), m:get(i+1, j)) 
+            end
+          end
+        end
+      end
+      for remStart = 1, nrow do 
+        for remEnd = remStart, nrow do 
+          if remStart ~= 1 and remEnd ~= nrow then
+            local smallMat = m:copy():remrow(remStart..remEnd)
+            assertEquals(smallMat.nrow, nrow - (remEnd-remStart+1))
+            for i = 1, smallMat.nrow do
+              for j = 1, ncol do 
+                if     i < remStart then assertEquals(smallMat:get(i, j), m:get(i                    , j))
+                elseif i > remEnd   then assertEquals(smallMat:get(i, j), m:get(i+(remEnd-remStart+1), j)) 
+                end
+              end
+            end
+          end
         end
       end
     end

--- a/tests/utests/matrix.mad
+++ b/tests/utests/matrix.mad
@@ -1586,7 +1586,7 @@ function TestMatrixInPlaceII:testCopy()
   end
 end
 
-function TestMatrixInPlaceII:testRemsub() --Need to test for ir or jc = nil (is remcol and remrow sufficient?)
+function TestMatrixInPlaceII:testRemsub()
   for _,m in ipairs(G.matidx) do
     local nrow, ncol = m:sizes()
     for startRem = 1, nrow - 1 do 

--- a/tests/utests/matrix.mad
+++ b/tests/utests/matrix.mad
@@ -1620,6 +1620,7 @@ function TestMatrixInPlaceII:testRemcol()
     if ncol > 1 then
       for colToRem = 1, ncol do 
         local smallMat = m:copy():remcol(colToRem)
+        assertEquals(smallMat, m:copy():remsub(nil, colToRem))
         assertEquals(ncol, smallMat.ncol + 1)
         for i = 1, nrow do
           for j = 1, ncol - 1 do 
@@ -1633,6 +1634,7 @@ function TestMatrixInPlaceII:testRemcol()
         for remEnd = remStart, ncol do 
           if remStart ~= 1 and remEnd ~= ncol then
             local smallMat = m:copy():remcol(remStart..remEnd)
+            assertEquals(smallMat, m:copy():remsub(nil, remStart..remEnd))
             assertEquals(smallMat.ncol, ncol - (remEnd-remStart+1))
             for i = 1, nrow do
               for j = 1, smallMat.ncol do 
@@ -1654,6 +1656,7 @@ function TestMatrixInPlaceII:testRemrow()
     if nrow > 1 then
       for rowToRem = 1, nrow do 
         local smallMat = m:copy():remrow(rowToRem)
+        assertEquals(smallMat, m:copy():remsub(rowToRem, nil))
         assertEquals(nrow, smallMat.nrow + 1)
         for i = 1, nrow - 1 do
           for j = 1, ncol do 
@@ -1667,6 +1670,7 @@ function TestMatrixInPlaceII:testRemrow()
         for remEnd = remStart, nrow do 
           if remStart ~= 1 and remEnd ~= nrow then
             local smallMat = m:copy():remrow(remStart..remEnd)
+            assertEquals(smallMat, m:copy():remsub(remStart..remEnd, nil))
             assertEquals(smallMat.nrow, nrow - (remEnd-remStart+1))
             for i = 1, smallMat.nrow do
               for j = 1, ncol do 


### PR DESCRIPTION
Improve remrow, remvec and remcol tests. remrow and remcol tests did not test iterables, while remvec was entirely insufficient.