### PR TITLE
Fix a typo in the GTPSA module

### DIFF
--- a/src/madl_gtpsa.mad
+++ b/src/madl_gtpsa.mad
@@ -477,14 +477,14 @@ function MR.get_mono (x, i, r) -- idx -> mono
   assert(is_integer(i), "invalid argument #2 (index expected)")
   local m = r or monomial(x.d.nn)
   assert(is_monomial(m), "invalid argument #2 (table or monomial expected)")
-  return _C.mad_tpsa_mono(t, m.n, m._dat, i-1) -- set m, return order
+  return _C.mad_tpsa_mono(x, m.n, m._dat, i-1) -- set m, return order
 end
 
 function MC.get_mono (x, i, r) -- idx -> mono
   assert(is_integer(i), "invalid argument #2 (index expected)")
   local m = r or monomial(x.d.nn)
   assert(is_monomial(m), "invalid argument #2 (table or monomial expected)")
-  return _C.mad_ctpsa_mono(t, m.n, m._dat, i-1) -- set m, return order
+  return _C.mad_ctpsa_mono(x, m.n, m._dat, i-1) -- set m, return order
 end
 
 function MR.cycle (x, i, m_) -- loop over indexes for non-zero value, (i=0 means end)


### PR DESCRIPTION
An undeclared variable ``t`` is used instead of the tpsa variable ``x``.