### PR TITLE
Fix typo in lst2tbl and improve tbl2str

### DIFF
--- a/src/madl_gutil.mad
+++ b/src/madl_gutil.mad
@@ -251,7 +251,7 @@ function utility.val2keys (a)
 end
 
 function utility.lst2tbl (l, t_)
-  assert(is_iterable(a), "invalid argument #1 (iterable expected)")
+  assert(is_iterable(l), "invalid argument #1 (iterable expected)")
   local n = #l
   local t = t_ or table.new(0,n)
   for i=1,n do t[l[i]] = true end
@@ -502,6 +502,8 @@ function utility.tbl2str (tbl, sep_)
       r[ir] = '[' ..k.. ']='..tostring_(v)
     elseif is_identifier(k) then
       r[ir] =       k..  '='..tostring_(v)
+    elseif is_logical(k) then
+      r[ir] = '['..tostring_(k)..']='..tostring_(v)
     else
       r[ir] = '["'..k..'"]='..tostring_(v)
     end


### PR DESCRIPTION
In the case of tbl2str, if the key is a boolean, an error would be thrown "attempt to concatenate a boolean value"