### PR TITLE
Element Map Fixes: RFCavity

### DIFF
--- a/src/madl_dynmap.mad
+++ b/src/madl_dynmap.mad
@@ -1347,7 +1347,7 @@ function M.rfcav_kickn (elm, m, lw) -- [KICKCAV, nmul ~= 0 or nbsl ~= 0]     -- 
       bx  = y*by + x*bx
       by  = byt
 
-      pt = pt + (bdir*_pc)*omega*by*sa
+      pt = pt - (bdir*_pc)*omega*by*sa
     end
 
     m[i].px = px

--- a/src/madl_etrck.mad
+++ b/src/madl_etrck.mad
@@ -618,11 +618,11 @@ local function track_rfcavgen (elm, m)
   local volt in elm
   local l = abs(ds)
 
-  m.el, m.eh, m.nmul = ds, 0, 0
+  m.el, m.eh = ds, 0
 
   local inter, kick
 
-  if abs(volt) < minvolt then
+  if abs(volt) < minvolt and not (m.ptcmodel and m.nmul ~= 0) then
     inter  = l < minlen  and thinonly or thickonly
     kick   = m.nmul == 0 and fnil     or strex_kick
   else


### PR DESCRIPTION
- The sign is opposite to what is done in PTC for `rfcav_kickn`
- Removed automatically setting of 0 for number of multipoles
- When ptcmodel is on and nmul > 0, force trackelm for the rfcavity