### PR TITLE
Element Map Fixes: RBend

### DIFF
--- a/src/madl_dynmap.mad
+++ b/src/madl_dynmap.mad
@@ -745,11 +745,14 @@ M.sbend_kick = \el,m,lw -> M.curex_kick(el,m,lw,true) ;                      -- 
 
 -- TKT [INTER_STREX] ----------------------------------------------------------o
 
-function M.rbend_thick_new (elm, m, lw) -- [SPAR]                            -- checked
+
+local function rbend_thick_new (elm, m, lw) -- [SPAR]                            -- checked
   m.atdebug(elm, m, lw, 'rbend_thick:0')
 
   local el, eld, knl, beam, T in m
-  local ld, k0 = (eld or el)*lw, knl[1]/abs(el)
+  -- local ld, k0 = (eld or el)*lw, knl[1]/abs(el)
+  local l, ld, k0 = el*lw, (eld or el)*lw, knl[1]/abs(eld)
+  local lw = (el/eld)*lw
   local beta, k0q, k0lq = beam.beta, k0*beam.charge, knl[1]*lw*beam.charge
 
   for i=1,m.npar do
@@ -766,11 +769,12 @@ function M.rbend_thick_new (elm, m, lw) -- [SPAR]                            -- 
     local   xi =  px*_ptt
     local zeta = npx*_ptt
     local  xtd = xi*sqrt(1-zeta^2) + zeta*sqrt(1-xi^2)
-    local   xt = ld*(2*px - k0lq)*_ptt^2 / xtd
+    local   xt = l*(2*px - k0lq)*_ptt^2 / xtd
     local  dxs = asinc(xt*k0q)*xt
 
+    -- MAD.dbg() 
     -- eq. 129 in Forest06 with modif. from Sagan
-    m[i].x  = x + ld*(2*px - k0lq) / (pz+pzs)
+    m[i].x  = x + l*(2*px - k0lq) / (pz+pzs)
     m[i].px = npx
     m[i].y  = y + dxs*py
     m[i].t  = t - dxs*(1/beta+pt) + (1-T)*ld/beta
@@ -779,11 +783,12 @@ function M.rbend_thick_new (elm, m, lw) -- [SPAR]                            -- 
   m.atdebug(elm, m, lw, 'rbend_thick:1')
 end
 
-function M.rbend_thick (elm, m, lw) -- [SPAR]                                -- checked
+local function rbend_thick_old (elm, m, lw) -- [SPAR]                                -- checked
   m.atdebug(elm, m, lw, 'rbend_thick:0')
 
   local el, eld, knl, beam, T in m
-  local ld, k0 = (eld or el)*lw, knl[1]/abs(el)
+  local ld, k0 = (eld or el)*lw, knl[1]/abs(eld)
+  local lw = (el/eld)*lw
   local beta, k0q, k0lq = beam.beta, k0*beam.charge, knl[1]*lw*beam.charge
 
   for i=1,m.npar do
@@ -809,7 +814,14 @@ function M.rbend_thick (elm, m, lw) -- [SPAR]                                -- 
   m.atdebug(elm, m, lw, 'rbend_thick:1')
 end
 
-M.rbend_kick = \el,m,lw -> M.strex_kick(el,m,lw,true)                        -- checked
+if new_bend_thick then 
+  M.rbend_thick = rbend_thick_new
+else
+  M.rbend_thick = rbend_thick_old
+end
+
+M.rbend_strex = \el,m,lw -> M.strex_kick(el,m,(m.el/m.eld)*lw) 
+M.rbend_kick = \el,m,lw -> M.strex_kick(el,m,lw,true)                          -- checked
 
 -- TKT [INTER_TKTF] -----------------------------------------------------------o
 

--- a/src/madl_etrck.mad
+++ b/src/madl_etrck.mad
@@ -68,7 +68,7 @@ local sbend_thick,  sbend_kick,
       sbend_thickf, sbend_kickf           , dipeg_fringe           in MAD.dynmap
 
 -- rbend (TKT)
-local rbend_thick,  rbend_kick                                     in MAD.dynmap
+local rbend_thick,  rbend_kick, rbend_strex                        in MAD.dynmap
 
 -- quadrupole (TKT)
 local quad_thick,  quad_kick,
@@ -349,7 +349,7 @@ local function track_rbend (elm, m)
   m.el, m.eld, m.eh = arc2cord(ds,angle), ds, angle/ds*tdir
   m.e1, m.e2, m.elc = e1, e2, m.el
 
-  io.write("eh=", m.eh, ", el=", m.el, ", eld=", m.eld, ", elc=", m.elc, ", e1=", m.e1, ", e2=", m.e2, "\n")
+  -- io.write("eh=", m.eh, ", el=", m.el, ", eld=", m.eld, ", elc=", m.elc, ", e1=", m.e1, ", e2=", m.e2, "\n")
 
   if nmul < 3 then
     m.nmul = max(abs(knl[3])+abs(ksl[3]) ~= 0 and 3 or
@@ -362,7 +362,7 @@ local function track_rbend (elm, m)
   local inter, thick, kick
 
   if model == 'DKD' then
-    inter, thick, kick = DKD[method], strex_drift, strex_kick
+    inter, thick, kick = DKD[method], strex_drift, rbend_strex
   else
     inter, thick, kick = DKD[method], rbend_thick, rbend_kick
   end


### PR DESCRIPTION
- Comment out printing
- Allow new_bend_thick flag to work
- Create new strex_kick for rbend to ensure weighted length is based on eld not el
- Force the weighting in the thick maps to be based on eld not el
- Switch some of the lengths to match the lengths used in PTC