### PR TITLE
Element Map Fixes: Quadrupole

### DIFF
--- a/src/madl_etrck.mad
+++ b/src/madl_etrck.mad
@@ -395,7 +395,7 @@ local function track_quadrupole (elm, m)
   local model  = elm.model  or m.model
   local method = elm.method or m.method
   local no_k1  = abs(knl[2]) < minstr
-  local no_k1s = abs(ksl[2]) < minstr
+  local no_k1s = abs(ksl[2]) < minstr or (elm.fringe > 0 and m.ptcmodel)
   local no_ang = abs(angle)  < minang
   local inter, thick, kick
 


### PR DESCRIPTION
- Add compatibility for ptc when fringe is on for a skew quadrupole