### PR TITLE
Fix Matrix and CMatrix Tests

### DIFF
--- a/tests/utests/cmatrix.mad
+++ b/tests/utests/cmatrix.mad
@@ -33,7 +33,7 @@ local sqrt, abs, log, exp, floor, round,
       sin, cos, tan, sinh, cosh, tanh, asin, acos, atan, asinh,
       acosh, atanh, atan2, hypot, erfc, erf, hypot3, acot, acoth,
       asinc, asinhc, acot, cot, coth, log10, sinc, sinhc         in MAD.gmath
-local chain, duplicate                                           in MAD.fun
+local duplicate                                                  in MAD.lfun
 local rep                                                        in MAD.utility
 local eps, tiny, huge, inf, nan, pi                              in MAD.constant
 local min, random, randomseed                                    in math

--- a/tests/utests/matrix.mad
+++ b/tests/utests/matrix.mad
@@ -34,7 +34,7 @@ local sqrt, abs, log, log10, exp, min, floor, round,
       sin, cos, tan, cot, sinh, cosh, tanh, coth, asin, acos, acot, atan, asinh,
       acosh, atanh, acoth, rangle, fact, erf, erfc, sinc, asinc,
       atan2, hypot, hypot3, asinhc, sinhc, cabs, carg                            in MAD.gmath
-local chain, duplicate                                           in MAD.fun
+local duplicate                                                  in MAD.lfun
 local rep                                                        in MAD.utility
 local min, randomseed, random                                    in math
 


### PR DESCRIPTION
Fix error after luafun was changed from `fun` to `lfun` in the MAD environment