### PR TITLE
Add Multipole to PTC test maps

### DIFF
--- a/tests/tests/test-ptc-maps/test-ptc-maps.mad
+++ b/tests/tests/test-ptc-maps/test-ptc-maps.mad
@@ -63,10 +63,11 @@ local function testQUADm() -- Test the multipole (~2 min)
     k1s  = \s->s.k1, !{0, -0.15, 0.2},  -- Test just multipole first
     knl  = {
       { }, 
-      {0.05, 0, 0, 0 }, 
-      {0   , 0, 5, 0 }, 
-      {0   , 0, 0, 50},
-      {0.05, 0, 5, 50},
+      {0.05, 0  , 0, 0 }, 
+      {0   , 0.5, 0, 0 }, 
+      {0   , 0  , 5, 0 }, 
+      {0   , 0  , 0, 50},
+      {0.05, 0  , 5, 50},
     },
     ksl  = \s-> s.knl,
     tilt = 0..2,
@@ -154,6 +155,39 @@ local function testDRIFT()
   }
   run_test(cfg)
 end
+
+local function testMULT() -- Test multipole (1 min)
+  local cfg = ref_cfg "multipole" {
+    elm =  [[
+      MULTIPOLE, at=0.75, lrad=1.5, 
+      knl=${knl}, ksl=${ksl}, angle=${angle}, tilt=${tilt}*pi/8
+    ]],
+    tol = 100,
+    energy = {1},
+    model  = {2}, -- Use TKT as faster
+    method = {2},
+    nslice = {3},
+
+    alist = tblcat(
+      ref_cfg.alist, 
+      {"knl", "ksl", "tilt", "angle"}
+    ),
+    knl = {
+      {0   , 0  , 0, 0 }, 
+      {0.05, 0  , 0, 0 }, 
+      {0   , 0.5, 0, 0 }, 
+      {0   , 0  , 5, 0 }, 
+      {0   , 0  , 0, 50},
+      {0.05, 0.5, 5, 50},
+    },
+    tilt  = 0..4,
+    ksl   = \s-> s.knl,
+    angle = \s-> {s.cur_cfg.knl[1]*1.5}, -- No effect?
+
+  }
+  run_test(cfg)
+end
+
 --[=[ 
 local function testSEXT()
   local cfg = ref_cfg "sextupole" {
@@ -398,21 +432,21 @@ end ]=]
 -------------------------------------------------------------------------------o
 
 -- Running the tests-----------------------------------------------------------o
-testDRIFT()
+!testDRIFT()
 -- testSBEND()
 -- testRBEND()
 -- testQUAD()
--- testQUADm()
--- testQUADf()
--- testQUADh()
--- testQUADfh()
+!testQUADm()
+!testQUADf()
+!testQUADh()
+!testQUADfh()
 -- testSEXT()
 -- testOCT()
 -- testDECA () -- Only actually tests the multipole
 -- testDODECA () -- Only actually tests the multipole
 -- testKICK()
 -- testELSEP()
--- testMULT()
+testMULT()
 -- testSOL()
 -- testCAV()
 -- testRFMULT()


### PR DESCRIPTION
Also:
- Added k1 to quadrupole multipole test
- Converted all \r\n to just \n 