### PR TITLE
Improve sbend kick

### DIFF
--- a/src/madl_dynmap.mad
+++ b/src/madl_dynmap.mad
@@ -613,13 +613,18 @@ end
 function M.curex_kick (elm, m, lw, no_k0l) -- [SKICK]                        -- checked
   m.atdebug(elm, m, lw, 'curex_kick:0', no_k0l)
 
-  local el, eh, tdir, nmul, knl, bfx, bfy, beam in m
+  local el, eh, tdir, nmul, knl, ksl, bfx, bfy, beam in m
   local bdir = tdir*beam.charge
 
   for i=1,m.npar do
     local x, px, y, py, beam in m[i]
     local bdir = beam and tdir*beam.charge or bdir
-    local bx, by = bxbyh(nmul, bfx, bfy, x, y)
+    local bx, by
+    if bfx[1] then 
+      bx, by = bxbyh(nmul, bfx, bfy, x, y)
+    else
+      bx, by = bxby (nmul, knl, ksl, x, y)
+    end
     local r = 1+eh*x
 
     m[i].px = px - (lw*bdir)*by*r

--- a/src/madl_etrck.mad
+++ b/src/madl_etrck.mad
@@ -41,7 +41,7 @@ local is_implicit                                               in element.drift
 
 local type = type
 
-local abs, max in math -- ensure that abs will not work on GTPSA.
+local abs, max, min in math -- ensure that abs will not work on GTPSA.
 
 -- redefine abs for this module (only!)
 local abs = \a -> type(a) == "number" and abs(a) or abs(a:get0())
@@ -299,17 +299,20 @@ local function track_sbend (elm, m, e1_, e2_)
   m.el, m.eh = ds, angle/ds*tdir
   m.e1, m.e2 = (e1_ or elm.e1), (e2_ or elm.e2)
 
-  if nmul < 3 then
-    m.nmul = max(abs(knl[3])+abs(ksl[3]) ~= 0 and 3 or
-                 abs(knl[2])+abs(ksl[2]) ~= 0 and 2 or
-                 abs(knl[1])+abs(ksl[1]) ~= 0 and 1 or 0, nmul)
-  end
-
   local model  = elm.model  or m.model
   local method = elm.method or m.method
   local inter, thick, kick
 
-  getanbnr(nmul, knl, ksl, m.eh, bfx, bfy)
+  if m.nmul == 3 then
+    nmul = min(abs(knl[3])+abs(ksl[3]) ~= 0 and 3 or
+               abs(knl[2])+abs(ksl[2]) ~= 0 and 2 or
+               abs(knl[1])+abs(ksl[1]) ~= 0 and 1 or 0, nmul)
+  end
+
+  if not (nmul == 1 and ksl[1] == 0) then
+    getanbnr(m.nmul, knl, ksl, m.eh, bfx, bfy)
+  end
+
   if model == 'DKD' then                          -- curved thin
     inter, thick, kick = DKD[method], curex_drift , curex_kick
   else -- if abs(knl[2]) < minstr then            -- curved thick


### PR DESCRIPTION
When only k0 exists, sbend_kick will now only use bxby instead of bxbyh.