### PR TITLE
Add ptcmodel flags in Sbend and Rbend

### DIFF
--- a/src/madl_etrck.mad
+++ b/src/madl_etrck.mad
@@ -362,7 +362,7 @@ local function track_sbend (elm, m, e1_, e2_)
 
   if model == 'DKD' then                          -- curved thin
     inter, thick, kick = DKD[method], curex_drift , curex_kick
-  elseif not m.ptcmodel and m.nmul == 1 and ksl[1] == 0 then         -- curved thick only
+  elseif m.nmul == 1 and ksl[1] == 0 and not m.ptcmodel then -- curved thick only
     inter, thick, kick = thickonly  , sbend_thick , fnil
   else -- if abs(knl[2]) < minstr then            -- curved thick
     inter, thick, kick = TKT[method], sbend_thick , sbend_kick
@@ -400,12 +400,12 @@ local function track_rbend (elm, m)
      or  ptcmodel and (e1==0 and e2==0 or e1~=0 and e2~=0) then
     m.e1, m.e2 = e1+angle/2, e2+angle/2
     m.el = m.elc
-  else                                                                        -- True parallel situation
+  else                                                                        -- True parallel
     if not ptcmodel and e1 or ptcmodel and e2==0 then
       m.e1, m.e2, m.etp_dir = e1, angle - e1, -1
       m.el = m.elc * cos(angle/2 - e1)
     else            
-      m.e1, m.e2, m.etp_dir = angle - e2, e2, ptcmodel and -1 or 1 -- edge true parallel dir decides when patch is performed.
+      m.e1, m.e2, m.etp_dir = angle - e2, e2, ptcmodel and -1 or 1            -- dir -> patch side.
       m.el = m.elc * cos(angle/2 - e2)
     end
     m.mang = m.e2
@@ -425,7 +425,7 @@ local function track_rbend (elm, m)
 
   if model == 'DKD' then
     inter, thick, kick = DKD[method], strex_drift, strex_kick
-  elseif not m.ptcmodel and m.nmul == 1 and ksl[1] == 0 then
+  elseif m.nmul == 1 and ksl[1] == 0 and not ptcmodel then
     inter, thick, kick = thickonly  , rbend_thick , fnil
   else
     inter, thick, kick = TKT[method], rbend_thick, rbend_kick
@@ -439,7 +439,7 @@ end
 local function track_quadrupole (elm, m)
   get_mult(elm, m, 2)
 
-  local ds, edir, tdir, nmul, knl, ksl in m
+  local ds, edir, tdir, nmul, knl, ksl, ptcmodel in m
   local angle, k0, k0s, k1, k1s in elm
   local l = abs(ds)
 
@@ -458,22 +458,22 @@ local function track_quadrupole (elm, m)
   local no_k1  = abs(knl[2]) < minstr
   local no_k1s = abs(ksl[2]) < minstr 
   local no_ang = abs(angle)  < minang
-  local no_tlt = m.ptcmodel and not no_k1s and (abs(knl[1]) > minstr or nmul > 2 or elm.fringe > 0)
-  local inter  = m.ptcmodel and KMK[method] or TKT[method]
+  local no_tlt = ptcmodel and not no_k1s and (abs(knl[1]) > minstr or nmul > 2 or elm.fringe > 0)
+  local inter  = ptcmodel and KMK[method] or TKT[method]
   local thick, kick
 
   if model == 'DKD' or no_k1 and no_k1s and no_ang then
     inter, thick, kick = DKD[method], strex_drift, strex_kick
   elseif no_k1s and no_ang or no_tlt then       -- normal thick
     m.k1 = knl[2]/ds*edir
-    thick, kick = quad_thick, m.ptcmodel and quad_kick or quad_kick_ysh
+    thick, kick = quad_thick, ptcmodel and quad_kick or quad_kick_ysh
   elseif no_ang then                            -- skew thick
     local a = -0.5*atan2(ksl[2], knl[2])
     m.k1, m.ca, m.sa = sqrt(knl[2]^2 + ksl[2]^2)/ds*edir, cos(a), sin(a)
-    thick, kick = quad_thicks, m.ptcmodel and quad_kicks or quad_kicks_ysh
+    thick, kick = quad_thicks, ptcmodel and quad_kicks or quad_kicks_ysh
   else                                          -- combined thick            -- unchecked
     m.eh = angle/ds*tdir
-    thick, kick = quad_thickh, m.ptcmodel and quad_kickh or quad_kickh_ysh
+    thick, kick = quad_thickh, ptcmodel and quad_kickh or quad_kickh_ysh
   end
 
   local track = #elm == 0 and trackelm or tracksub

--- a/src/madl_etrck.mad
+++ b/src/madl_etrck.mad
@@ -362,7 +362,7 @@ local function track_sbend (elm, m, e1_, e2_)
 
   if model == 'DKD' then                          -- curved thin
     inter, thick, kick = DKD[method], curex_drift , curex_kick
-  elseif m.nmul == 1 and ksl[1] == 0 then         -- curved thick only
+  elseif not m.ptcmodel and m.nmul == 1 and ksl[1] == 0 then         -- curved thick only
     inter, thick, kick = thickonly  , sbend_thick , fnil
   else -- if abs(knl[2]) < minstr then            -- curved thick
     inter, thick, kick = TKT[method], sbend_thick , sbend_kick
@@ -374,16 +374,16 @@ local function track_sbend (elm, m, e1_, e2_)
 end
 
 local function track_rbend (elm, m)
-  local angle, e1, e2, true_rbend in elm
+  local angle, e1, e2, true_rbend, truerbend, ptcrbend in elm
 
   m.mang = 0
-  if not true_rbend then                                                      -- checked
+  if not (true_rbend or truerbend or ptcrbend) then                           -- checked
     return track_sbend(elm, m, e1+angle/2, e2+angle/2)
   end
 
   get_mult(elm, m, 3)                                                         -- unchecked
 
-  local ds, tdir, nmul, knl, ksl in m
+  local ds, tdir, nmul, knl, ksl, ptcmodel in m
   local k0, k0s, k1, k1s, k2, k2s in elm
 
   if abs(ds) < minlen then
@@ -396,15 +396,16 @@ local function track_rbend (elm, m)
   m.eld = ds
   m.elc = arc2cord(ds, angle)
 
-  if e1 and e2 then                                                           -- Will require m.ptcmodel
-    m.e1, m.e2 = e1, e2
+  if not ptcmodel and e1 and e2 
+     or  ptcmodel and (e1==0 and e2==0 or e1~=0 and e2~=0) then
+    m.e1, m.e2 = e1+angle/2, e2+angle/2
     m.el = m.elc
   else                                                                        -- True parallel situation
-    if e1 then                                                                -- Will require m.ptcmodel
+    if not ptcmodel and e1 or ptcmodel and e2==0 then
       m.e1, m.e2, m.etp_dir = e1, angle - e1, -1
       m.el = m.elc * cos(angle/2 - e1)
     else            
-      m.e1, m.e2, m.etp_dir = angle - e2, e2,  1 -- edge true parallel dir decides when patch is performed.
+      m.e1, m.e2, m.etp_dir = angle - e2, e2, ptcmodel and -1 or 1 -- edge true parallel dir decides when patch is performed.
       m.el = m.elc * cos(angle/2 - e2)
     end
     m.mang = m.e2
@@ -424,7 +425,7 @@ local function track_rbend (elm, m)
 
   if model == 'DKD' then
     inter, thick, kick = DKD[method], strex_drift, strex_kick
-  elseif m.nmul == 1 and ksl[1] == 0 then
+  elseif not m.ptcmodel and m.nmul == 1 and ksl[1] == 0 then
     inter, thick, kick = thickonly  , rbend_thick , fnil
   else
     inter, thick, kick = TKT[method], rbend_thick, rbend_kick


### PR DESCRIPTION
- For debugging only (otherwise equivalent), force NG to kick even with nmul == 1 and ksl[1]==0
- Add true parallel ptcmodel flags
- Only a draft pull request since:  ```m.e1, m.e2 = e1+angle/2, e2+angle/2``` has also been added, but this update may not have been pushed yet.