### PR TITLE
Misalignment Fixes

### DIFF
--- a/src/madl_dynmap.mad
+++ b/src/madl_dynmap.mad
@@ -365,7 +365,7 @@ end
 function misalignent (elm, m, lw)                                            -- unchecked
   m.atdebug(elm, m, lw, 'misalign:0')
 
-  local sdir, tdir, algn in m
+  local sdir, edir, tdir, algn in m
 
   -- misalignment at entry and local/global frames
   -- forward : x1' = R*x1+T
@@ -373,21 +373,21 @@ function misalignent (elm, m, lw)                                            -- 
 
   -- rotate
   if algn.rot and sdir > 0 then
-    yrotation( algn.dthe, m,  1)
-    xrotation(-algn.dphi, m,  1)
-    srotation( algn.dpsi, m,  1)
+    yrotation( algn.dthe, m, edir)
+    xrotation(-algn.dphi, m, edir)
+    srotation( algn.dpsi, m, edir)
   end
 
   -- translate
   if algn.trn then
-    translate({dx=algn.dx*tdir, dy=algn.dy*tdir, ds=algn.ds*sdir}, m, sdir)
+    translate({dx=algn.dx, dy=algn.dy, ds=algn.ds}, m, sdir)
   end
 
   -- rotate
   if algn.rot and sdir < 0 then
-    srotation( algn.dpsi, m, -1)
-    xrotation(-algn.dphi, m, -1)
-    yrotation( algn.dthe, m, -1)
+    srotation( algn.dpsi, m, -edir)
+    xrotation(-algn.dphi, m, -edir)
+    yrotation( algn.dthe, m, -edir)
   end
 
   m.atdebug(elm, m, lw, 'misalign:1')
@@ -396,7 +396,7 @@ end
 function misalignexi (elm, m, lw)                                            -- unchecked
   m.atdebug(elm, m, lw, 'misalignexi:0')
 
-  local el, ang, tlt, sdir, tdir, algn in m
+  local el, ang, tlt, sdir, edir, tdir, algn in m
   local mang = m.mang or ang
 
   -- translation
@@ -420,22 +420,22 @@ function misalignexi (elm, m, lw)                                            -- 
   -- rotate
   if algn.rot and sdir > 0 then
     local ax, ay, az = _Rb:torotzxy()
-    srotation(az, m, -1)
-    xrotation(ax, m, -1)
-    yrotation(ay, m, -1)
+    srotation(az, m, -edir)
+    xrotation(ax, m, -edir)
+    yrotation(ay, m, -edir)
   end
 
   -- translate
   if algn.trn then
-    translate({dx=_Tb[1]*tdir, dy=_Tb[2]*tdir, ds=_Tb[3]*sdir}, m, -sdir)
+    translate({dx=_Tb[1], dy=_Tb[2], ds=_Tb[3]}, m, -sdir)
   end
 
   -- rotate
   if algn.rot and sdir < 0 then
     local ax, ay, az = _Rb:torotzxy()
-    yrotation(ay, m, 1)
-    xrotation(ax, m, 1)
-    srotation(az, m, 1)
+    yrotation(ay, m, edir)
+    xrotation(ax, m, edir)
+    srotation(az, m, edir)
   end
 
   m.atdebug(elm, m, lw, 'misalignexi:1')

--- a/src/madl_geomap.mad
+++ b/src/madl_geomap.mad
@@ -189,7 +189,7 @@ end
 function misalignent (elm, m, lw)
   m.atdebug(elm, m, lw, 'misalign:0')
 
-  local sdir, algn, V, W in m
+  local sdir, tdir, algn, V, W in m
 
   -- misalignment at entry and global frame
   -- forward : x1' = R*x1+T      => V = V+W*T   ; W = W*R
@@ -197,19 +197,19 @@ function misalignent (elm, m, lw)
 
   -- translate
   if algn.trn and sdir > 0 then
-    _T:fill{algn.dx, algn.dy, algn.ds}
+    _T:fill{algn.dx*tdir, algn.dy*tdir, algn.ds*sdir}
     V:add(W:mul(_T, U), V)  -- V = V+W*T
   end
 
   -- rotate
   if algn.rot then
-    _R:rotzxy(-algn.dphi, algn.dthe, algn.dpsi, sdir<0)
+    _R:rotzxy(-algn.dphi, algn.dthe, algn.dpsi, tdir<0)
     W:mul(_R, W)            -- W = W*R or W*R:t()
   end
 
   -- translate
   if algn.trn and sdir < 0 then
-    _T:fill{algn.dx, algn.dy, algn.ds}
+    _T:fill{algn.dx*tdir, algn.dy*tdir, algn.ds*sdir}
     V:sub(W:mul(_T, U), V)  -- V = V-W*T
   end
 
@@ -219,14 +219,16 @@ end
 function misalignexi (elm, m, lw)
   m.atdebug(elm, m, lw, 'misalignexi:0')
 
-  local el, ang, tlt, sdir, algn, V, W in m
+  local el, ang, tlt, sdir, tdir, algn, V, W in m
   local mang = m.mang or ang
 
   -- translation
-  if algn.trn then _T:fill{algn.dx, algn.dy, algn.ds} else T:zeros() end
+  if algn.trn 
+  then _T:fill{algn.dx*tdir, algn.dy*tdir, algn.ds*sdir} 
+  else _T:zeros() end
 
   -- rotation
-  if algn.rot then _R:rotzxy(-algn.dphi, algn.dthe, algn.dpsi) end
+  if algn.rot then _R:rotzxy(-algn.dphi, algn.dthe, algn.dpsi, tdir<0) end
 
   -- compute Rbar, Tbar
   _C.mad_mat_rtbar(_Rb._dat, _Tb._dat, abs(el), mang, tlt, algn.rot and _R._dat or nil, _T._dat)


### PR DESCRIPTION
- Add edir to dynmap 
- Remove multiplication of tdir and sdir in translate (done in the actual function)
- Change sdir to tdir in geomap for rotation (like above)
- Add tdir and sdir multiplications in translate for geomap (translate is only the matrix)