### PR TITLE
Test vs PTC adjustments and fixes

### DIFF
--- a/tests/tests/test-ptc-maps/test-octupole-maps.mad
+++ b/tests/tests/test-ptc-maps/test-octupole-maps.mad
@@ -37,7 +37,7 @@ local function testOCT() -- Test the body (~2 min)
     nslice = 1..3,
     energy = {1, 6500},  -- {1, 450, 6500}
 
-    tol = 120,
+    tol = 130,
 
     k3     = {-15, 0, 20},
     k3s    = { 15, 0, 20},
@@ -68,7 +68,7 @@ local function testOCTm() -- Test the multipole (~2 min)
   local cfg = ref_cfg "octm" {
     elm = [[
       OCTUPOLE, at=0.75, l=1.5, k3=${k3}, k3s=${k3s}, tilt=${tilt}*pi/16,
-      knl=${knl}, ksl=${ksl}, fringe_max=${fringe_max}, fringe=7, bend_fringe=true
+      knl=${knl}, ksl=${ksl}, fringe_max=${fringe_max}, fringe=19, bend_fringe=true
     ]],
     
     tol = 300,
@@ -130,7 +130,7 @@ local function testOCTf() -- Test the fringe (~1 min)
       fringe=${fringe}, f1=${f1}, f2=${f2}
     ]],
     
-    tol = 25,
+    tol = 75,
 
     model  = {1}, 
     method = {2},    
@@ -138,7 +138,7 @@ local function testOCTf() -- Test the fringe (~1 min)
     energy = {1},
 
     tilt   = 0..4,
-    fringe = {0, 7},
+    fringe = {0, 19},
     k3   = {0, 20},
     k3s  = \s->s.k3,
     f1   = {0, 0.5, -0.7},
@@ -167,7 +167,7 @@ local function testOCTh()
       knl={${k0}}
     ]],
     
-    tol = 25,
+    tol = 90,
     
     model  = {1}, -- Use DKD as otherwise PTC broken
     method = {2},    
@@ -214,7 +214,7 @@ local function testOCTfh() -- MAD-NG does bend fringe for fringe=3
     nslice = {1},
     energy = {1},
 
-    fringe      = {7},
+    fringe      = {19},
     k3          = {0, 20},
     k3s         = \s->s.k3,
     k0          = {0, 0.05},
@@ -245,7 +245,7 @@ end
 local function testOCThe ()
   local cfg = ref_cfg "octhe" {
     elm = [[
-      OCTUPOLE, at=0.75, l=1.5, k3=${k3}, k3s=${k3s}, fringe=7,
+      OCTUPOLE, at=0.75, l=1.5, k3=${k3}, k3s=${k3s}, fringe=19,
       knl={${k0}}, e1=${e1}, e2=${e2}, h1=${h1}, h2=${h2}, bend_fringe=true
     ]],
     

--- a/tests/tests/test-ptc-maps/test-sextupole-maps.mad
+++ b/tests/tests/test-ptc-maps/test-sextupole-maps.mad
@@ -37,7 +37,7 @@ local function testSEXT() -- Test the body (~2 min)
     nslice = 1..3,
     energy = {1, 6500},  -- {1, 450, 6500}
 
-    tol = 120,
+    tol = 50,
 
     k2     = {-0.15, 0, 0.2},
     k2s    = {-0.15, 0, 0.2},
@@ -70,10 +70,10 @@ local function testSEXTm() -- Test the multipole (~2 min)
   local cfg = ref_cfg "sextm" {
     elm = [[
       SEXTUPOLE, at=0.75, l=1.5, k2=${k2}, k2s=${k2s}, tilt=${tilt}*pi/12,
-      knl=${knl}, ksl=${ksl}, fringe_max=${fringe_max}, fringe=7, bend_fringe=true
+      knl=${knl}, ksl=${ksl}, fringe_max=${fringe_max}, fringe=19, bend_fringe=true
     ]],
     
-    tol = 300,
+    tol = 150,
 
     model  = {1}, 
     method = {2},
@@ -129,7 +129,7 @@ local function testSEXTf() -- Test the fringe (~1 min)
   local cfg = ref_cfg "sextf" {
     elm = [[
       SEXTUPOLE, at=0.75, l=1.5, k2=${k2}, k2s=${k2s}, tilt=${tilt}*pi/12,
-      fringe=${fringe}, f1=${f1}, f2=${f2}
+      fringe=${fringe}, f1=${f1}, f2=${f2}, fringe_max=${fringe_max},
     ]],
     
     tol = 25,
@@ -140,12 +140,15 @@ local function testSEXTf() -- Test the fringe (~1 min)
     energy = {1},
 
     tilt   = 0..4,
-    fringe = {0, 7},
+    fringe = {0, 19},
+    fringe_max = 2..5,
     k2   = {0, 0.2},
     k2s  = \s->s.k2,
     f1   = {0, 0.5, -0.7},
     f2   = {0, -0.5, 0.7},
-    alist = tblcat(ref_cfg.alist, {"tilt", "fringe", "k2", "k2s", "f1", "f2"}),
+    alist = tblcat(
+      ref_cfg.alist, {"tilt", "fringe", "k2", "k2s", "f1", "f2", "fringe_max"}
+    ),
     plot_info = {
       title       = "Sextupole Fringe Comparison",
       series      = {
@@ -206,7 +209,8 @@ local function testSEXTfh() -- MAD-NG does bend fringe for fringe=3
   local cfg = ref_cfg "sextfh" {
     elm = [[
       SEXTUPOLE, at=0.75, l=1.5, k2=${k2}, k2s=${k2s}, fringe=${fringe},
-      knl={${k0}}, fint=${fint}, fintx=${fintx}, hgap=${hgap}, bend_fringe=true
+      knl={${k0}}, fint=${fint}, fintx=${fintx}, hgap=${hgap}, bend_fringe=true,
+      fringe_max=4
     ]],
     
     tol = 25,
@@ -216,7 +220,7 @@ local function testSEXTfh() -- MAD-NG does bend fringe for fringe=3
     nslice = {1},
     energy = {1},
 
-    fringe      = {7},
+    fringe      = {19},
     k2          = {0, 0.2},
     k2s         = \s->s.k2,
     k0          = {0, 0.05},
@@ -247,11 +251,11 @@ end
 local function testSEXThe ()
   local cfg = ref_cfg "sexthe" {
     elm = [[
-      SEXTUPOLE, at=0.75, l=1.5, k2=${k2}, k2s=${k2s}, fringe=7,
+      SEXTUPOLE, at=0.75, l=1.5, k2=${k2}, k2s=${k2s}, fringe=19, fringe_max=4,
       knl={${k0}}, e1=${e1}, e2=${e2}, h1=${h1}, h2=${h2}, bend_fringe=true
     ]],
     
-    tol = 600,
+    tol = 650,
     
     model  = {1},
     method = {2},

--- a/tests/tests/test-ptc-maps/test-sol-maps.mad
+++ b/tests/tests/test-ptc-maps/test-sol-maps.mad
@@ -69,22 +69,24 @@ end
 
 local function testSOLf()
   local cfg = ref_cfg "solf" {
-    elm =  "SOLENOID, at=0.75, l=1.5, ks=${ks}, fringe=${fringe}, knl=${knl}, bend_fringe=false",
+    elm =  "SOLENOID, at=0.75, l=1.5, ks=${ks}, fringe=${fringe}, knl=${knl}, bend_fringe=false,\z
+            fringe_max=${fringe_max}",
     
     model  = {2},
     method = {2, 6},    
     nslice = 1..3,
     energy = {1},  -- {1, 450, 6500}
 
-    tol = 1000,
+    tol = 1700,
 
-    alist = tblcat(ref_cfg.alist, {"ks", "fringe", "knl"}),
+    alist = tblcat(ref_cfg.alist, {"ks", "fringe", "knl", "fringe_max"}),
     ks       = {-0.6, 0, 0.3},
     knl = {
       {0   , 0  , 0, 0 }, 
       {0.05, 0.5, 5, 50},
     },
     fringe   = {14, 0}, -- 14 - qsad, solen and mult_fringe
+    fringe_max = 2..5,  
 
     plot_info = {
       series = {
@@ -106,7 +108,8 @@ end
 
 local function testSOLm()
   local cfg = ref_cfg "solm" {
-    elm =  "SOLENOID, at=0.75, lrad=1.5, ksi=${ksi}, knl=${knl}, ksl=${ksl}, fringe=${fringe};",
+    elm =  "SOLENOID, at=0.75, lrad=1.5, ksi=${ksi}, knl=${knl}, ksl=${ksl}, fringe=${fringe},\z
+            fringe_max=${fringe_max}",
     
     model  = {1},
     method = {2, 6},    
@@ -115,7 +118,7 @@ local function testSOLm()
 
     tol = 100,
 
-    alist = tblcat(ref_cfg.alist, {"ksi", "fringe", "knl", "ksl"}),
+    alist = tblcat(ref_cfg.alist, {"ksi", "fringe", "knl", "ksl", "fringe_max"}),
     knl = {
       {0   , 0  , 0, 0 }, 
       {0.05, 0.5, 5, 50},
@@ -123,6 +126,7 @@ local function testSOLm()
     ksi   = {-0.2, 0, 0.25},
     ksl   = \s-> s.knl,
     fringe   = 0..14..14,
+    fringe_max = 2..5,
 
     plot_info = {
       series = {


### PR DESCRIPTION
The following changes were made to the tests

Solenoid:
- Adjust tolerances
- Add fringe_max

Sextupole:
- Adjust tolerances
- Add fringe_max
- Adjust bit number for fringe (using old number)

Octupole:
- Adjust tolerances
- Adjust bit number for fringe (using old number)