### PR TITLE
Fix damap initial conditions in track

### DIFF
--- a/src/madl_track.mad
+++ b/src/madl_track.mad
@@ -435,7 +435,7 @@ local function make_mflow (self)
   assert(is_number  (s0), "invalid s0 (number expected)")
   assert(is_iterable(X0), "invalid X0 (iterable expected)")
   assert(is_iterable(O0), "invalid O0 (iterable expected)")
-  if not is_iterable(X0[1]) or is_beta0(X0) then X0 = {X0} end
+  if not is_iterable(X0[1]) or is_beta0(X0) or is_damap(X0) then X0 = {X0} end
 
   -- damap defs and save
   local mapdef, savemap in self


### PR DESCRIPTION
Since the update of tpsa becoming iterable, add test for damap in track initial coordinates