### PR TITLE
Solenoid Length Weighting Fix

### DIFF
--- a/src/madl_dynmap.mad
+++ b/src/madl_dynmap.mad
@@ -547,7 +547,7 @@ function M.strex_kickhs (elm, m, lw) -- [KICKT]                              -- 
     -- solenoid
     if ksi ~= 0 and lrad ~= 0 then
       local px, py in m[i]
-      local  hss = sdir*(ksi^2/lrad) -- 4 H(s_0)^2/ds
+      local  hss = lw*sdir*(ksi^2/lrad) -- 4 H(s_0)^2/ds
       local _dpp = 1/pz
       local _dp  = _dpp^2
       local  ang = (wchg*0.5*ksi)*_dpp


### PR DESCRIPTION
This error was not caught due to the tests w/ PTC using multipoles therefore lw==1