### PR TITLE
Improve NG vs NG Tests

### DIFF
--- a/tests/tests/test-ng-maps/test-ng-maps.mad
+++ b/tests/tests/test-ng-maps/test-ng-maps.mad
@@ -71,7 +71,7 @@ local function testQUAD() -- Test the body (~2 min)
   local cfg = ref_cfg "quad" {
     elm = "quadrupole 'quad' {at=0.75, l=1.5, k1=${bdir}*${k1}, k1s=${bdir}*${k1s},tilt=${tilt}, fringe=0}",
     model  = 1..2,
-    method = 2..6..2,    
+    method = {"'teapot4'", 2, 4, 6, 8, "'teapot'"},    
     nslice = 1..3,
     energy = {1, 6500},  -- {1, 450, 6500}
 
@@ -180,7 +180,7 @@ end
 
 local function testSBEND() -- Test the body (~2 min)
   local cfg = ref_cfg "sbend" {
-    elm = "sbend 'sbend' {at=0.75, l=1.5, k0=${bdir}*math.pi/${angle_div}, angle=${tdir}*math.pi/${angle_div}*1.5, fringe=0}",
+    elm = "sbend 'sbend' {at=0.75, l=1.5, k0=${k0}*${bdir}*math.pi/${angle_div}, angle=${tdir}*math.pi/${angle_div}*1.5, fringe=0}",
     model  = {1, 2},
     method = 2..8..2,    
     nslice = 1..3,
@@ -189,7 +189,8 @@ local function testSBEND() -- Test the body (~2 min)
     tol = 600,
 
     angle_div = {50, 100, 200, 500, 1000},
-    alist = tblcat(ref_cfg.alist, {"angle_div"}),
+    k0        = {0, 0.8, 1, 1.2},
+    alist = tblcat(ref_cfg.alist, {"angle_div", "k0"}),
 
     plot_info = {
       title    = "SBend NG v NG Maps",
@@ -204,7 +205,7 @@ end
 local function testRBEND() -- Test the body (~2 min)
   local cfg = ref_cfg "rbend" {
     elm = [[rbend 'rbend' {
-      at=0.75, l=1.5, k0=${bdir}*math.pi/${angle_div}, angle=${tdir}*math.pi/${angle_div}*1.5, fringe=0, 
+      at=0.75, l=1.5, k0=${k0}*${bdir}*math.pi/${angle_div}, angle=${tdir}*math.pi/${angle_div}*1.5, fringe=0, 
       e1 = ${tdir}*${e1}*math.pi/${angle_div}*1.5, e2 = ${tdir}*${e2}*math.pi/${angle_div}*1.5,
       true_rbend = ${true_rbend},
     }]],
@@ -215,11 +216,12 @@ local function testRBEND() -- Test the body (~2 min)
 
     tol = 2000,
 
-    angle_div = {50, 100, 200, 500, 1000},
+    angle_div = {50, 200, 1000},
+    k0        = {0, 0.8, 1},
     true_rbend = {false, true},
     e1 = {-0.15, 0, 0.2},
     e2 = {-0.2, 0, 0.15},
-    alist = tblcat(ref_cfg.alist, {"true_rbend", "angle_div", "e1", "e2"}),
+    alist = tblcat(ref_cfg.alist, {"true_rbend", "k0", "angle_div", "e1", "e2"}),
 
     plot_info = {
       title    = "RBend NG v NG Maps",
@@ -262,7 +264,7 @@ end
 
 local function testRFMULTIPOLE()
   local cfg = ref_cfg "rfmultipole" {
-    elm = "${element} 'rfm' {at=0.75, l=${l}, volt=0, freq=75, knl=${knl}, fringe=0}",
+    elm = "${element} 'rfm' {at=1.5, l=0, volt=0, freq=1, knl=${knl}, fringe=0}",
     model  = {1, 2},
     method = 2..8..2,
     nslice = 1..3,
@@ -275,22 +277,21 @@ local function testRFMULTIPOLE()
 
     knl = {
       {0, 0, 0, 0},
-      {0.5, 0, 0, 0},
+      -- {0.5, 0, 0, 0},
       {0, 5, 0, 0},
       {0, 0, 50, 0},
       {0, 0, 0, 500},
-      {0.5, 5, 50, 500},
+      -- {0.5, 5, 50, 500},
     },
     alist = tblcat(ref_cfg.alist, {"knl"}),
   }
 
   local equiv = object "rfm" {
     multipole = object {
-      "element", "l",
+      "element",
       element := {
         "multipole"
       },
-      l = {0},
 
       n = 1,
     },
@@ -312,9 +313,69 @@ local function testSOL()
 
     ks = -0.6..0.6..0.3,
     alist = tblcat(ref_cfg.alist, {"ks"}),
+    plot_info = {
+      title    = "Solenoid NG v NG Maps",
+      filename = "solenoid-ngvng.png",
+      series   = default_plot_cfg.series,
+      legend   = default_plot_cfg.legend,
+    },
   }
+  
   run_test(cfg, {alist={}})
 end
+
+local function testRFCAVITY()
+  local cfg = ref_cfg "rfcav" {
+    elm = "rfcavity 'rfcav' {l=1.5, volt=${bdir}*${volt}, freq=${freq}, lag=${lag}, fringe=0}",
+    model  = {1, 2},
+    method = 2..8..2,
+    nslice = 1..3,
+    energy = {1, 6500},
+
+    tol = 100,
+
+    volt = {-8, 0, 8},
+    freq = {75, 150, 225},
+    lag  = {0, 0.8},
+    alist = tblcat(ref_cfg.alist, {"volt", "freq", "lag"}),
+
+    plot_info = {
+      title    = "RF Cavity NG v NG Maps",
+      filename = "rfcav-ngvng.png",
+      series   = default_plot_cfg.series,
+      legend   = default_plot_cfg.legend,
+    },  
+  }
+
+  run_test(cfg, {alist={}})
+end
+
+local function testKICKER()
+  local cfg = ref_cfg "kicker" {
+    elm = "kicker 'kicker' {at=0.75, l=1.5, hkick=${bdir}*${hkick}, vkick=${bdir}*${vkick}}",
+
+    model  = {1, 2},
+    method = 2..8..2,
+    nslice = 1..3,
+    energy = {1, 6500},
+
+    tol = 5,
+
+    hkick = {-2e-3, 0, 1.5e-3},
+    vkick = {-2e-3, 0, 1.5e-3},
+    alist = tblcat(ref_cfg.alist, {"hkick", "vkick"}),
+
+    plot_info = {
+      title    = "Kicker NG v NG Maps",
+      filename = "kicker-ngvng.png",
+      series   = default_plot_cfg.series,
+      legend   = default_plot_cfg.legend,
+    },  
+  }
+
+  run_test(cfg, {alist={}})
+end
+
 
 testQUAD()
 testSEXT()
@@ -322,5 +383,7 @@ testOCT()
 testSBEND()
 testRBEND()
 testRBENDPARALLEL()
--- testRFMULTIPOLE()
+testRFMULTIPOLE()
 testSOL()
+testRFCAVITY()
+testKICKER()

--- a/tests/tests/test-ng-maps/test-ng-maps.mad
+++ b/tests/tests/test-ng-maps/test-ng-maps.mad
@@ -286,19 +286,7 @@ local function testRFMULTIPOLE()
     alist = tblcat(ref_cfg.alist, {"knl"}),
   }
 
-  local equiv = object "rfm" {
-    multipole = object {
-      "element",
-      element := {
-        "multipole"
-      },
-
-      n = 1,
-    },
-
-    alist = {"multipole"},
-  }
-  run_test(cfg, equiv)
+  run_test(cfg, {alist={}})
 end
 
 local function testSOL()


### PR DESCRIPTION
- Elements now missing from this test suite: 
  - Electrostatic separator
  - Crab cavity (falls under rfmultipole, needs #331 accepted to test first.)
  - Multipole (mainly strex_kick**h**s as solenoid part tested in solenoid test and strex_kick is DKD in most cases)