### PR TITLE
Fix quad kick names

### DIFF
--- a/src/madl_etrck.mad
+++ b/src/madl_etrck.mad
@@ -543,14 +543,14 @@ local function track_quadrupole (elm, m)
     inter, thick, kick = DKD[method], strex_drift, strex_kick
   elseif no_k1s and no_ang or no_tlt then       -- normal thick
     m.k1 = knl[2]/ds*edir
-    thick, kick = quad_thick, ptcmodel and quad_kick or quad_kick_ysh
+    thick, kick = quad_thick, ptcmodel and quad_kick_ or quad_kick
   elseif no_ang then                            -- skew thick
     local a = -0.5*atan2(ksl[2], knl[2])
     m.k1, m.ca, m.sa = sqrt(knl[2]^2 + ksl[2]^2)/ds*edir, cos(a), sin(a)
-    thick, kick = quad_thicks, ptcmodel and quad_kicks or quad_kicks_ysh
+    thick, kick = quad_thicks, ptcmodel and quad_kicks_ or quad_kicks
   else                                          -- combined thick            -- unchecked
     m.eh = angle/ds*tdir
-    thick, kick = quad_thickh, ptcmodel and quad_kickh or quad_kickh_ysh
+    thick, kick = quad_thickh, ptcmodel and quad_kickh_ or quad_kickh
   end
 
   local track = #elm == 0 and trackelm or tracksub
@@ -574,7 +574,7 @@ local function track_strexgen (elm, m, ptc_, mth_)
     inter, thick, kick, fringe = DKD[method], strex_drift, strex_kick, strex_fringe
   else
     m.k1 = m.knl[2]/m.ds*m.edir
-    inter, thick, kick, fringe = KMK[method], quad_thick, quad_kick, strex_fringe
+    inter, thick, kick, fringe = KMK[method], quad_thick, quad_kick_, strex_fringe
   end
 
   local track = #elm == 0 and trackelm or tracksub


### PR DESCRIPTION
Due to 
- quad_kick_ysh -> quad_kick
- quad_kick         -> quad_kick_ (KMK)