### PR TITLE
Rbend Fixes

### DIFF
--- a/src/madl_dynmap.mad
+++ b/src/madl_dynmap.mad
@@ -1806,7 +1806,7 @@ end
 
 function bend_wedge (elm, m, lw_, e) -- [WEDGE] see also [sr]bend_thick      -- checked
   if e == 0 then return end
-  if abs(m.knl[1]) < minstr then return yrotation(-e,m,1) end
+  if abs(m.knl[1]) < minstr then return yrotation(elm,m,1,-e) end
   m.atdebug(elm, m, lw_, 'bend_wedge:0')
 
   local el, eld, tdir, knl, beam in m

--- a/src/madl_etrck.mad
+++ b/src/madl_etrck.mad
@@ -391,7 +391,7 @@ local function cfringe (elm, m, dir, frng)
     c.a = p and (m.e2 or elm.e2)*m.tdir - c.e or 0
   else
     c.e, c.h  = (m.e2 or elm.e2)*m.tdir, elm.h2*m.tdir
-    c.a = p and (m.e1 or elm.e1)*m.tdir - c.e or 0
+    c.a = p and c.e - (m.e1 or elm.e1)*m.tdir or 0
   end
 
   if ftst(c.frng, fringe.bend) then

--- a/src/madl_etrck.mad
+++ b/src/madl_etrck.mad
@@ -717,7 +717,7 @@ local function track_rbend (elm, m)
   end
 
   l = abs(m.el)
-  m.eh = angle*edir/l
+  m.eh = angle*edir/abs(m.eld)                                                -- Must be divided by eld.
 
   knl[1], ksl[1] = knl[1]+k0*l  , ksl[1]+k0s*l
   knl[2], ksl[2] = knl[2]+k1*l  , ksl[2]+k1s*l


### PR DESCRIPTION
- Fix usage of yrotation, due to recent changes
- Ensure patch of true parallel rbend is identical on entry and exit 
- Restore curvature calculation to be based on eld