### PR TITLE
Fix Multipole Shortcut

### DIFF
--- a/src/mad_dynmap.cpp
+++ b/src/mad_dynmap.cpp
@@ -476,7 +476,7 @@ inline void strex_kicks (mflw_t *m, num_t lw, P &p, T &pz)
 template <typename P, typename T=P::T>
 inline void strex_kickhs (mflw_t *m, num_t lw, int is)
 {                                            (void)is;
-  if (!m->nmul == 0 || !m->ksi) return;
+  if (!m->nmul && !m->ksi) return;
   mdump(0);
   num_t wchg = lw*m->sdir*m->edir*m->charge;
   T bx, by;


### PR DESCRIPTION
#### Before
If nmul > 0 or ksi == 0, skip the map

#### After 
If nmul ==  0 and ksi == 0, skip the map