### PR TITLE
Change l_pz calculation to make drift more stable

### DIFF
--- a/src/mad_dynmap.cpp
+++ b/src/mad_dynmap.cpp
@@ -399,11 +399,11 @@ inline void drift_adj (mflw_t *m, num_t l)
   mdump(0);
   FOR(i,m->npar) {
     P p(m,i);
-    T l_pz = invsqrt(1 + 2/m->beta*p.pt + sqr(p.pt) - sqr(p.px) - sqr(p.py), l);
+    T _pz = invsqrt(1 + 2/m->beta*p.pt + sqr(p.pt) - sqr(p.px) - sqr(p.py));
 
-    p.x += p.px*(l_pz-l);
-    p.y += p.py*(l_pz-l);
-    p.t -= l_pz*(1/m->beta+p.pt) + (m->T-1)*l/m->beta;
+    p.x += p.px*(l*_pz-l);
+    p.y += p.py*(l*_pz-l);
+    p.t -= _pz*(l/m->beta+p.pt) + (m->T-1)*l/m->beta;
   }
   mdump(1);
 }
@@ -420,11 +420,11 @@ inline void strex_drift (mflw_t *m, num_t lw, int is)
 
   FOR(i,m->npar) {
     P p(m,i);
-    T l_pz = invsqrt(1 + 2/m->beta*p.pt + sqr(p.pt) - sqr(p.px) - sqr(p.py), l);
+    T _pz = invsqrt(1 + 2/m->beta*p.pt + sqr(p.pt) - sqr(p.px) - sqr(p.py));
 
-    p.x += p.px*l_pz;
-    p.y += p.py*l_pz;
-    p.t -= l_pz*(1/m->beta+p.pt) + (m->T-1)*ld/m->beta;
+    p.x += p.px*l*_pz;
+    p.y += p.py*l*_pz;
+    p.t -= _pz*(l/m->beta+p.pt) + (m->T-1)*ld/m->beta;
   }
   mdump(1);
 }
@@ -898,14 +898,14 @@ inline void solen_thick (mflw_t *m, num_t lw, int is)
 
   FOR (i,m->npar) {
     P p(m,i);
-    T    xp = p.px + bsol*p.y;
-    T    yp = p.py - bsol*p.x;
-    T  l_pz = invsqrt(1 + (2/m->beta)*p.pt + sqr(p.pt) - sqr(xp) - sqr(yp), l);
-    T   ang = l_pz*bsol;
+    T   xp = p.px + bsol*p.y;
+    T   yp = p.py - bsol*p.x;
+    T  _pz = invsqrt(1 + (2/m->beta)*p.pt + sqr(p.pt) - sqr(xp) - sqr(yp));
+    T  ang = _pz*(l*bsol);
 
     T ca = cos(ang), sa = sin(ang), sc = sinc(ang);
 
-    T lsc = l_pz*sc;
+    T lsc = l*_pz*sc;
     T xt  = ca*p.x  + lsc*p.px;
     T pxt = ca*p.px - lsc*p.x *sqr(bsol);
     T yt  = ca*p.y  + lsc*p.py;
@@ -915,7 +915,7 @@ inline void solen_thick (mflw_t *m, num_t lw, int is)
     p.px = ca*pxt + sa*pyt;
     p.y  = ca*yt  - sa*xt;
     p.py = ca*pyt - sa*pxt;
-    p.t -= l_pz*(1/m->beta+p.pt) + (m->T-1)*l/m->beta;
+    p.t -= _pz*(l/m->beta+p.pt) + (m->T-1)*l/m->beta;
   }
   mdump(1);
 }


### PR DESCRIPTION
I found this version of drift to be more stable for T, specifically the `_pz*(l/m->beta+p.pt) + (m->T-1)*l/m->beta;` calculation 