### PR TITLE
Patch fixes

### DIFF
--- a/src/mad_dynmap.cpp
+++ b/src/mad_dynmap.cpp
@@ -250,9 +250,8 @@ inline void xrotation (cflw<M> &m, num_t lw, const V &dphi_)
 {
   if (fabs(dphi_)+fabs(m.dphi) < minang) return;
   mdump(0);
-  lw *= m.sdir*m.edir;
   P a;
-  if (fval(dphi_)) a = lw*dphi_; else a = lw*R(m.dphi);
+  if (fval(dphi_)) a = lw*dphi_; else a = m.sdir*m.edir*lw*R(m.dphi);
   P sa=sin(a), ca=cos(a), ta=tan(a);
 
   FOR(i,m.npar) {
@@ -276,9 +275,8 @@ inline void yrotation (cflw<M> &m, num_t lw, const V &dthe_)
 {
   if (fabs(dthe_)+fabs(m.dthe) < minang) return;
   mdump(0);
-  lw *= -m.sdir*m.edir;
   P a;
-  if (fval(dthe_)) a = lw*dthe_; else a = lw*R(m.dthe);
+  if (fval(dthe_)) a = -lw*dthe_; else a = -lw*m.sdir*m.edir*R(m.dthe);
   P sa=sin(a), ca=cos(a), ta=tan(a);
 
   FOR(i,m.npar) {
@@ -302,9 +300,8 @@ inline void srotation (cflw<M> &m, num_t lw, const V &dpsi_)
 {
   if (fabs(dpsi_)+fabs(m.dpsi) < minang) return;
   mdump(0);
-  lw *= m.sdir*m.edir;
   P a;
-  if (fval(dpsi_)) a = lw*dpsi_; else a = lw*R(m.dpsi);
+  if (fval(dpsi_)) a = lw*dpsi_; else a = lw*m.sdir*m.edir*R(m.dpsi);
   P sa=sin(a), ca=cos(a);
 
   FOR(i,m.npar) {

--- a/src/mad_dynmap.cpp
+++ b/src/mad_dynmap.cpp
@@ -358,18 +358,19 @@ inline void changeref (cflw<M> &m, num_t lw)
   mdump(0);
   lw *= m.sdir;
 
+// By not placing the rotation as the third argument of the function, weighting is done by the function
   if (rot && lw > 0) {
-    yrotation<M>(m,  m.edir, zero);
-    xrotation<M>(m, -m.edir, zero);
-    srotation<M>(m,  m.edir, zero);
+    yrotation<M>(m,  m.sdir, zero);
+    xrotation<M>(m, -m.sdir, zero);
+    srotation<M>(m,  m.sdir, zero);
   }
 
   if (trn) translate<M>(m, 1, zero, zero, zero);
 
   if (rot && lw < 0) {
-    srotation<M>(m, -m.edir, zero);
-    xrotation<M>(m,  m.edir, zero);
-    yrotation<M>(m, -m.edir, zero);
+    srotation<M>(m, -m.sdir, zero);
+    xrotation<M>(m,  m.sdir, zero);
+    yrotation<M>(m, -m.sdir, zero);
   }
   mdump(1);
 }

--- a/src/mad_dynmap.cpp
+++ b/src/mad_dynmap.cpp
@@ -1513,63 +1513,63 @@ inline void rfcav_fringe (cflw<M> &m, num_t lw)
 
 // --- patches ---
 
-void mad_trk_xrotation_r (mflw_t *m, num_t lw) {
+void mad_trk_xrotation_r (mflw_t *m, num_t lw, int _) {
   xrotation<par_t>(m->rflw, lw, zero);
 }
-void mad_trk_yrotation_r (mflw_t *m, num_t lw) {
+void mad_trk_yrotation_r (mflw_t *m, num_t lw, int _) {
   yrotation<par_t>(m->rflw, lw, zero);
 }
-void mad_trk_srotation_r (mflw_t *m, num_t lw) {
+void mad_trk_srotation_r (mflw_t *m, num_t lw, int _) {
   srotation<par_t>(m->rflw, lw, zero);
 }
-void mad_trk_translate_r (mflw_t *m, num_t lw) {
+void mad_trk_translate_r (mflw_t *m, num_t lw, int _) {
   translate<par_t>(m->rflw, lw, zero, zero, zero);
 }
-void mad_trk_changeref_r (mflw_t *m, num_t lw) {
+void mad_trk_changeref_r (mflw_t *m, num_t lw, int _) {
   changeref<par_t>(m->rflw, lw);
 }
 
-void mad_trk_xrotation_t (mflw_t *m, num_t lw) {
+void mad_trk_xrotation_t (mflw_t *m, num_t lw, int _) {
   xrotation<map_t>(m->tflw, lw, zero);
 }
-void mad_trk_yrotation_t (mflw_t *m, num_t lw) {
+void mad_trk_yrotation_t (mflw_t *m, num_t lw, int _) {
   yrotation<map_t>(m->tflw, lw, zero);
 }
-void mad_trk_srotation_t (mflw_t *m, num_t lw) {
+void mad_trk_srotation_t (mflw_t *m, num_t lw, int _) {
   srotation<map_t>(m->tflw, lw, zero);
 }
-void mad_trk_translate_t (mflw_t *m, num_t lw) {
+void mad_trk_translate_t (mflw_t *m, num_t lw, int _) {
   translate<map_t>(m->tflw, lw, zero, zero, zero);
 }
-void mad_trk_changeref_t (mflw_t *m, num_t lw) {
+void mad_trk_changeref_t (mflw_t *m, num_t lw, int _) {
   changeref<map_t>(m->tflw, lw);
 }
 
-void mad_trk_xrotation_p (mflw_t *m, num_t lw) {
+void mad_trk_xrotation_p (mflw_t *m, num_t lw, int _) {
   xrotation<prm_t>(m->pflw, lw, zero);
 }
-void mad_trk_yrotation_p (mflw_t *m, num_t lw) {
+void mad_trk_yrotation_p (mflw_t *m, num_t lw, int _) {
   yrotation<prm_t>(m->pflw, lw, zero);
 }
-void mad_trk_srotation_p (mflw_t *m, num_t lw) {
+void mad_trk_srotation_p (mflw_t *m, num_t lw, int _) {
   srotation<prm_t>(m->pflw, lw, zero);
 }
-void mad_trk_translate_p (mflw_t *m, num_t lw) {
+void mad_trk_translate_p (mflw_t *m, num_t lw, int _) {
   translate<prm_t>(m->pflw, lw, zero, zero, zero);
 }
-void mad_trk_changeref_p (mflw_t *m, num_t lw) {
+void mad_trk_changeref_p (mflw_t *m, num_t lw, int _) {
   changeref<prm_t>(m->pflw, lw);
 }
 
 // --- misalignment ---
 
-void mad_trk_misalign_r (mflw_t *m, num_t lw) {
+void mad_trk_misalign_r (mflw_t *m, num_t lw, int _) {
   misalign<par_t>(m->rflw, lw);
 }
-void mad_trk_misalign_t (mflw_t *m, num_t lw) {
+void mad_trk_misalign_t (mflw_t *m, num_t lw, int _) {
   misalign<map_t>(m->tflw, lw);
 }
-void mad_trk_misalign_p (mflw_t *m, num_t lw) {
+void mad_trk_misalign_p (mflw_t *m, num_t lw, int _) {
   misalign<prm_t>(m->pflw, lw);
 }
 

--- a/src/mad_dynmap.h
+++ b/src/mad_dynmap.h
@@ -39,28 +39,28 @@ void mad_trk_slice_tpt (mflw_t *m, num_t lw, trkfun *dft, trkfun *kck, int knd);
 void mad_trk_slice_one (mflw_t *m, num_t lw, trkfun *dft_or_kck);               // single
 
 // -- patches
-void mad_trk_xrotation_r    (mflw_t *m, num_t lw);
-void mad_trk_yrotation_r    (mflw_t *m, num_t lw);
-void mad_trk_srotation_r    (mflw_t *m, num_t lw);
-void mad_trk_translate_r    (mflw_t *m, num_t lw);
-void mad_trk_changeref_r    (mflw_t *m, num_t lw);
+void mad_trk_xrotation_r    (mflw_t *m, num_t lw, int _);
+void mad_trk_yrotation_r    (mflw_t *m, num_t lw, int _);
+void mad_trk_srotation_r    (mflw_t *m, num_t lw, int _);
+void mad_trk_translate_r    (mflw_t *m, num_t lw, int _);
+void mad_trk_changeref_r    (mflw_t *m, num_t lw, int _);
 
-void mad_trk_xrotation_t    (mflw_t *m, num_t lw);
-void mad_trk_yrotation_t    (mflw_t *m, num_t lw);
-void mad_trk_srotation_t    (mflw_t *m, num_t lw);
-void mad_trk_translate_t    (mflw_t *m, num_t lw);
-void mad_trk_changeref_t    (mflw_t *m, num_t lw);
+void mad_trk_xrotation_t    (mflw_t *m, num_t lw, int _);
+void mad_trk_yrotation_t    (mflw_t *m, num_t lw, int _);
+void mad_trk_srotation_t    (mflw_t *m, num_t lw, int _);
+void mad_trk_translate_t    (mflw_t *m, num_t lw, int _);
+void mad_trk_changeref_t    (mflw_t *m, num_t lw, int _);
 
-void mad_trk_xrotation_p    (mflw_t *m, num_t lw);
-void mad_trk_yrotation_p    (mflw_t *m, num_t lw);
-void mad_trk_srotation_p    (mflw_t *m, num_t lw);
-void mad_trk_translate_p    (mflw_t *m, num_t lw);
-void mad_trk_changeref_p    (mflw_t *m, num_t lw);
+void mad_trk_xrotation_p    (mflw_t *m, num_t lw, int _);
+void mad_trk_yrotation_p    (mflw_t *m, num_t lw, int _);
+void mad_trk_srotation_p    (mflw_t *m, num_t lw, int _);
+void mad_trk_translate_p    (mflw_t *m, num_t lw, int _);
+void mad_trk_changeref_p    (mflw_t *m, num_t lw, int _);
 
 // -- misalign
-void mad_trk_misalign_r     (mflw_t *m, num_t lw);
-void mad_trk_misalign_t     (mflw_t *m, num_t lw);
-void mad_trk_misalign_p     (mflw_t *m, num_t lw);
+void mad_trk_misalign_r     (mflw_t *m, num_t lw, int _);
+void mad_trk_misalign_t     (mflw_t *m, num_t lw, int _);
+void mad_trk_misalign_p     (mflw_t *m, num_t lw, int _);
 
 // -- fringe maps
 void mad_trk_strex_fringe_r (mflw_t *m, num_t lw);

--- a/src/madl_cmad.mad
+++ b/src/madl_cmad.mad
@@ -926,31 +926,31 @@ void mad_trk_slice_dkd (mflw_t *m, num_t lw, trkfun *dft, trkfun *kck, int ord);
 void mad_trk_slice_tkt (mflw_t *m, num_t lw, trkfun *dft, trkfun *kck, int ord);
 void mad_trk_slice_kmk (mflw_t *m, num_t lw, trkfun *dft, trkfun *kck, int ord);
 void mad_trk_slice_tpt (mflw_t *m, num_t lw, trkfun *dft, trkfun *kck, int knd);
-void mad_trk_slice_one (mflw_t *m, num_t lw, trkfun *dft);
+void mad_trk_slice_one (mflw_t *m, num_t lw, trkfun *dft_or_kck);
 
 // -- patches
-void mad_trk_xrotation_r    (mflw_t *m, num_t lw);
-void mad_trk_yrotation_r    (mflw_t *m, num_t lw);
-void mad_trk_srotation_r    (mflw_t *m, num_t lw);
-void mad_trk_translate_r    (mflw_t *m, num_t lw);
-void mad_trk_changeref_r    (mflw_t *m, num_t lw);
+void mad_trk_xrotation_r    (mflw_t *m, num_t lw, int _);
+void mad_trk_yrotation_r    (mflw_t *m, num_t lw, int _);
+void mad_trk_srotation_r    (mflw_t *m, num_t lw, int _);
+void mad_trk_translate_r    (mflw_t *m, num_t lw, int _);
+void mad_trk_changeref_r    (mflw_t *m, num_t lw, int _);
 
-void mad_trk_xrotation_t    (mflw_t *m, num_t lw);
-void mad_trk_yrotation_t    (mflw_t *m, num_t lw);
-void mad_trk_srotation_t    (mflw_t *m, num_t lw);
-void mad_trk_translate_t    (mflw_t *m, num_t lw);
-void mad_trk_changeref_t    (mflw_t *m, num_t lw);
+void mad_trk_xrotation_t    (mflw_t *m, num_t lw, int _);
+void mad_trk_yrotation_t    (mflw_t *m, num_t lw, int _);
+void mad_trk_srotation_t    (mflw_t *m, num_t lw, int _);
+void mad_trk_translate_t    (mflw_t *m, num_t lw, int _);
+void mad_trk_changeref_t    (mflw_t *m, num_t lw, int _);
 
-void mad_trk_xrotation_p    (mflw_t *m, num_t lw);
-void mad_trk_yrotation_p    (mflw_t *m, num_t lw);
-void mad_trk_srotation_p    (mflw_t *m, num_t lw);
-void mad_trk_translate_p    (mflw_t *m, num_t lw);
-void mad_trk_changeref_p    (mflw_t *m, num_t lw);
+void mad_trk_xrotation_p    (mflw_t *m, num_t lw, int _);
+void mad_trk_yrotation_p    (mflw_t *m, num_t lw, int _);
+void mad_trk_srotation_p    (mflw_t *m, num_t lw, int _);
+void mad_trk_translate_p    (mflw_t *m, num_t lw, int _);
+void mad_trk_changeref_p    (mflw_t *m, num_t lw, int _);
 
 // -- misalign
-void mad_trk_misalign_r     (mflw_t *m, num_t lw);
-void mad_trk_misalign_t     (mflw_t *m, num_t lw);
-void mad_trk_misalign_p     (mflw_t *m, num_t lw);
+void mad_trk_misalign_r     (mflw_t *m, num_t lw, int _);
+void mad_trk_misalign_t     (mflw_t *m, num_t lw, int _);
+void mad_trk_misalign_p     (mflw_t *m, num_t lw, int _);
 
 // -- fringe maps
 void mad_trk_strex_fringe_r (mflw_t *m, num_t lw);

--- a/src/madl_dynmap.mad
+++ b/src/madl_dynmap.mad
@@ -138,7 +138,7 @@ end
 -- X-rotation
 
 local function xrotation (elm, m, lw_, dphi_)  -- Rx(ax) [ROT_YZ]            -- checked
-  local ax = dphi_ or m.ang*m.tdir
+  local ax = dphi_ or m.dphi*m.tdir
   if abs(ax) < minang then return end
 
   m.atdebug(elm, m, 'xrotation:0')
@@ -171,7 +171,7 @@ M.xrotation = xrotation
 -- Y-rotation
 
 local function yrotation (elm, m, lw_, dthe_)  -- Ry(ay) [ROT_XZ]            -- checked
-  local ay = dthe_ or m.ang*m.tdir
+  local ay = dthe_ or m.dthe*m.tdir
   if abs(ay) < minang then return end
 
   m.atdebug(elm, m, 'yrotation:0')
@@ -204,7 +204,7 @@ M.yrotation = yrotation
 -- S-rotation
 
 local function srotation (elm, m, lw_, dpsi_)  -- Rz(az) [ROT_XY]            -- checked
-  local az = dpsi_ or m.ang*m.tdir
+  local az = dpsi_ or m.dpsi*m.tdir
   if abs(az) < minang then return end
 
   m.atdebug(elm, m, 'srotation:0')

--- a/src/madl_etrck.mad
+++ b/src/madl_etrck.mad
@@ -525,7 +525,6 @@ local function crot (elm, m, dir)
   if m.cmap then
     m.cflw.dpsi = m.tlt
     map[m.cmap][srotation](m.cflw_, dir, 0)
-    m.cflw.dpsi = 0
   else
     srotation(elm, m, dir, m.tlt)
   end
@@ -708,11 +707,18 @@ local function track_marker (elm, m)
   trackone(elm, m, thinonly, fnil)
 end
 
+local rot_angles = {
+  [yrotation] = "dthe",
+  [xrotation] = "dphi",
+  [srotation] = "dpsi",
+}
+
 local function track_rotation (elm, m, rot)
-  m.ang = elm.angle
+  local ang = rot_angles[rot]
+  m[ang] = elm.angle
 
   if m.cmap then
-    m.cflw.ang = m.ang
+    m.cflw[ang] = m[ang]
   end
 
   trackone(elm, m, thinonly, rot)

--- a/src/madl_etrck.mad
+++ b/src/madl_etrck.mad
@@ -526,7 +526,8 @@ local function crot (elm, m, dir)
     m.cflw.dpsi = m.tlt
     map[m.cmap][srotation](m.cflw_, dir, 0)
   else
-    srotation(elm, m, dir, m.tlt)
+    m.dpsi = m.tlt
+    srotation(elm, m, dir)
   end
 end
 
@@ -592,7 +593,7 @@ end
 
 local function trackelm (elm, m, inter, thick, thin, fringe)
   local sdir, atentry, atexit in m
-  local tlt  = elm.tilt*m.tdir  ; m.tlt  = tlt
+  local tlt  = elm.tilt; m.tlt  = tlt
   local algn = get_algn(elm, m) ; m.algn = algn
   local mis  = algn and cmisalign or fnil
   local rot  = abs(tlt) >= minang and crot or fnil
@@ -627,7 +628,7 @@ local function tracksub (elm, m, inter, thick, thin, fringe)
   end
 
   local eidx, sdir, atentry, atexit, __sdat in m
-  local tlt  = elm.tilt*m.tdir  ; m.tlt  = tlt
+  local tlt  = elm.tilt; m.tlt  = tlt
   local algn = get_algn(elm, m) ; m.algn = algn
   local mis  = algn and cmisalign or fnil
   local rot  = abs(tlt) >= minang and crot or fnil

--- a/src/madl_etrck.mad
+++ b/src/madl_etrck.mad
@@ -523,10 +523,9 @@ end
 
 local function crot (elm, m, dir)
   if m.cmap then
-    m.cflw.tlt = m.tlt
-    map[m.cmap][srotation](m.cflw_, dir)
+    map[m.cmap][srotation](m.cflw_, dir, m.tlt)
   else
-    srotation(elm, m, dir)
+    srotation(elm, m, dir, m.tlt)
   end
 end
 

--- a/src/madl_etrck.mad
+++ b/src/madl_etrck.mad
@@ -523,7 +523,9 @@ end
 
 local function crot (elm, m, dir)
   if m.cmap then
-    map[m.cmap][srotation](m.cflw_, dir, m.tlt)
+    m.cflw.dpsi = m.tlt
+    map[m.cmap][srotation](m.cflw_, dir, 0)
+    m.cflw.dpsi = 0
   else
     srotation(elm, m, dir, m.tlt)
   end
@@ -531,7 +533,7 @@ end
 
 local function cmisalign (elm, m, dir)
   if m.cmap then
-    map[m.cmap][misalign](m.cflw_, dir)
+    map[m.cmap][misalign](m.cflw_, dir, 0)
   else
     misalign(elm, m, dir)
   end


### PR DESCRIPTION
### Reason for solution:
Loss of symmetry between C++ and Lua has been observed in the (x/y/s)rotation patches. 
In these cases we have
- Lua:
  - patches rely on input of d(the/phi/psi)_ or m.ang
- C 
  - patches rely on d(the/phi/psi)_ or m.d(the/phi/psi)

The sbend also uses the attribute m.ang, which could be a problem for a tilted sbend if we do not use the optional parameter, therefore in the current setup, we required the tilt to be used as an extra attribute.

The srotation cannot be used with this extra attribute _directly from Lua_, due to the use of `typedef void (trkfun) (mflw_t*, num_t, int);` therefore, we **must** set the srotation using m.dthe.

So in order to keep the symmetry, I also forced lua to use m.d(the/phi/psi)

### Fixes List
- Make all patches follow trkfun format.
- Add third argument to patches so that they run in trackone
- Fix tilt so that srotation is performed in C and Lua
- Fix symmetry between Lua and C
- Make Lua and C attitude to optional arguments and m.d(the/phi/psi) identical
- Force tilt in Lua and C to work the same
- Change changeref due to above