### PR TITLE
Fix multipole fringe

### DIFF
--- a/src/madl_etrck.mad
+++ b/src/madl_etrck.mad
@@ -792,7 +792,7 @@ local function track_multipole (elm, m)
     cpy_mult(m)
   end
 
-  trackelm(elm, m, thinonly, kick)
+  trackelm(elm, m, thinonly, kick, nil, fnil)
 end
 
 local function track_bbeam (elm, m)


### PR DESCRIPTION
Make fringe explicitly fnil in multipole (so nil value is not called)