### PR TITLE
Fix KMK in PTC model & KMK quad_kick 

### DIFF
--- a/src/mad_dynmap.cpp
+++ b/src/mad_dynmap.cpp
@@ -794,10 +794,8 @@ inline void quad_kick (cflw<M> &m, num_t lw, int is)
   if (fabs(m.k1) < minstr) return strex_kick<M>(m, lw, is);
 
   P l = R(m.el)*lw;
-  if (is >= 0) {
-    if (!is) l /= 2;
-    drift_adj<M>(m, l);
-  }
+  num_t dw = is == 0 ? 1./2 : 1.; // drift weight
+  if (is >= 0) drift_adj<M>(m, dw*l);
 
   mdump(0);
   if (m.nmul > 0) {
@@ -814,7 +812,7 @@ inline void quad_kick (cflw<M> &m, num_t lw, int is)
   }
   mdump(1);
 
-  if (is <= 0) drift_adj<M>(m, l);
+  if (is <= 0) drift_adj<M>(m, dw*l);
 }
 
 template <typename M, typename T=M::T, typename P=M::P, typename R=M::R>
@@ -862,10 +860,8 @@ inline void quad_kicks (cflw<M> &m, num_t lw, int is)
   if (fabs(m.k1) < minstr) return strex_kick<M>(m, lw, is);
 
   P l = R(m.el)*lw;
-  if (is >= 0) {
-    if (!is) l /= 2;
-    drift_adj<M>(m, l);
-  }
+  num_t dw = is == 0 ? 1./2 : 1.; // drift weight
+  if (is >= 0) drift_adj<M>(m, dw*l);
 
   mdump(0);
   if (m.nmul > 0) {
@@ -882,7 +878,7 @@ inline void quad_kicks (cflw<M> &m, num_t lw, int is)
   }
   mdump(1);
 
-  if (is <= 0) drift_adj<M>(m, l);
+  if (is <= 0) drift_adj<M>(m, dw*l);
 }
 
 template <typename M, typename T=M::T, typename P=M::P, typename R=M::R>
@@ -947,11 +943,9 @@ inline void quad_kickh (cflw<M> &m, num_t lw, int is)
 {                                           (void)is;
   P l  = R(m.el)*lw;
   P lh = R(m.eh)*l;
+  num_t dw = is == 0 ? 1./2 : 1.; // drift weight
 
-  if (is >= 0) {
-    if (!is) l /= 2;
-    drift_adj<M>(m, l);
-  }
+  if (is >= 0) drift_adj<M>(m, dw*l);
 
   mdump(0);
   if (m.nmul > 0) {
@@ -970,7 +964,7 @@ inline void quad_kickh (cflw<M> &m, num_t lw, int is)
   }
   mdump(1);
 
-  if (is <= 0) drift_adj<M>(m, l);
+  if (is <= 0) drift_adj<M>(m, dw*l);
 }
 
 // --- solenoid ---

--- a/src/madl_etrck.mad
+++ b/src/madl_etrck.mad
@@ -1020,7 +1020,8 @@ local function track_strexgen (elm, m, ptc_, mth_)
     inter, thick, kick, fringe = DKD[method], strex_drift, strex_kick, strex_fringe
   else
     m.k1 = m.knl[2]/l*m.tdir
-    inter, thick, kick, fringe = KMK[method], quad_thick, quad_kick_, strex_fringe
+    inter = method > 2 and KMK[method] or TKT[method]
+    thick, kick, fringe = quad_thick, quad_kick_, strex_fringe
   end
 
   if m.cmap and not m.pmap then

--- a/src/madl_etrck.mad
+++ b/src/madl_etrck.mad
@@ -970,7 +970,7 @@ local function track_quadrupole (elm, m)
   local no_k1s = abs(ksl[2]) < minstr 
   local no_ang = abs(angle)  < minang
   local no_tlt = ptcmodel and not no_k1s and (abs(knl[1]) > minstr or nmul > 2 or elm.fringe > 0)
-  local inter  = ptcmodel and KMK[method] or TKT[method]
+  local inter  = ptcmodel and method > 2 and KMK[method] or TKT[method]
   local thick, kick
 
   if model == 'DKD' or no_k1 and no_k1s and no_ang then


### PR DESCRIPTION
- Create a new variable called dw (**d**rift **w**eight)
- Ensure that yoshida is used for KMK method 2 (when using ptcmodel)