### PR TITLE
Fix charge dependancy of qsad_fringe

### DIFF
--- a/src/mad_dynmap.cpp
+++ b/src/mad_dynmap.cpp
@@ -1325,7 +1325,6 @@ inline void qsad_fringe (cflw<M> &m, num_t lw)
   if (fabs(m.f1)    +fabs(m.f2)     < minstr) return;
 
   mdump(0);
-  num_t wchg = lw*m.charge;
   P     a    = -0.5*atan2(R(m.ksl[1]), R(m.knl[1]));
   P     b2   = hypot(R(m.knl[1]), R(m.ksl[1]))/R(m.el)*m.edir;
   P     ca   = cos(a), sa = sin(a);
@@ -1338,8 +1337,8 @@ inline void qsad_fringe (cflw<M> &m, num_t lw)
     T _pz = invsqrt(1 + 2/m.beta*p.pt + sqr(p.pt));
     T  dt = (1/m.beta+p.pt)*_pz;
 
-    T  f1 = wchg*bf1*_pz;
-    T  f2 =      bf2*_pz;
+    T  f1 = lw*m.charge*bf1*_pz;
+    T  f2 =    m.charge*bf2*_pz;
 
     T nx  = ca*p.x  + sa*p.y;
     T npx = ca*p.px + sa*p.py;

--- a/src/madl_dynmap.mad
+++ b/src/madl_dynmap.mad
@@ -1908,7 +1908,7 @@ function qsad_fringe (elm, m, lw) -- [FRINGE2QUAD]                           -- 
 
   local el, eld, tdir, k1, ca, sa, beam in m
   local beta = beam.beta
-  local wchg = beam.charge*lw
+  local  chg = beam.charge
 
   local edir, knl, ksl in m
   local a  = -0.5*atan2(ksl[2], knl[2])
@@ -1922,12 +1922,12 @@ function qsad_fringe (elm, m, lw) -- [FRINGE2QUAD]                           -- 
   for i=1,m.npar do
     local x, px, y, py, t, pt, beam in m[i]
     local beta = beam and beam.beta or beta
-    local wchg = beam and beam.charge*lw or wchg
+    local  chg = beam and beam.charge or chg
     local  _pz = invsqrt(1 + 2/beta*pt + pt^2)
     local   dt = (1/beta+pt)*_pz
 
-    local f1 = (wchg*f1)*_pz
-    local f2 =       f2 *_pz
+    local f1 = (lw*chg*f1)*_pz
+    local f2 = (   chg*f2)*_pz
 
     local nx  = ca*x  + sa*y
     local npx = ca*px + sa*py


### PR DESCRIPTION
Performing an ng vs ng test reveals that for the map to be fully reversed when chg is reversed, f2 must also be multiplied

**HOWEVER** I am not sure if f2 should also be multiplied by lw. It is not in PTC (but it's also not multiplied by charge), so this needs to be reviewed.