### PR TITLE
Patch fixes

### DIFF
--- a/src/mad_dynmap.cpp
+++ b/src/mad_dynmap.cpp
@@ -1509,63 +1509,63 @@ inline void rfcav_fringe (cflw<M> &m, num_t lw)
 
 // --- patches ---
 
-void mad_trk_xrotation_r (mflw_t *m, num_t lw) {
+void mad_trk_xrotation_r (mflw_t *m, num_t lw, int _) {
   xrotation<par_t>(m->rflw, lw, zero);
 }
-void mad_trk_yrotation_r (mflw_t *m, num_t lw) {
+void mad_trk_yrotation_r (mflw_t *m, num_t lw, int _) {
   yrotation<par_t>(m->rflw, lw, zero);
 }
-void mad_trk_srotation_r (mflw_t *m, num_t lw) {
+void mad_trk_srotation_r (mflw_t *m, num_t lw, int _) {
   srotation<par_t>(m->rflw, lw, zero);
 }
-void mad_trk_translate_r (mflw_t *m, num_t lw) {
+void mad_trk_translate_r (mflw_t *m, num_t lw, int _) {
   translate<par_t>(m->rflw, lw, zero, zero, zero);
 }
-void mad_trk_changeref_r (mflw_t *m, num_t lw) {
+void mad_trk_changeref_r (mflw_t *m, num_t lw, int _) {
   changeref<par_t>(m->rflw, lw);
 }
 
-void mad_trk_xrotation_t (mflw_t *m, num_t lw) {
+void mad_trk_xrotation_t (mflw_t *m, num_t lw, int _) {
   xrotation<map_t>(m->tflw, lw, zero);
 }
-void mad_trk_yrotation_t (mflw_t *m, num_t lw) {
+void mad_trk_yrotation_t (mflw_t *m, num_t lw, int _) {
   yrotation<map_t>(m->tflw, lw, zero);
 }
-void mad_trk_srotation_t (mflw_t *m, num_t lw) {
+void mad_trk_srotation_t (mflw_t *m, num_t lw, int _) {
   srotation<map_t>(m->tflw, lw, zero);
 }
-void mad_trk_translate_t (mflw_t *m, num_t lw) {
+void mad_trk_translate_t (mflw_t *m, num_t lw, int _) {
   translate<map_t>(m->tflw, lw, zero, zero, zero);
 }
-void mad_trk_changeref_t (mflw_t *m, num_t lw) {
+void mad_trk_changeref_t (mflw_t *m, num_t lw, int _) {
   changeref<map_t>(m->tflw, lw);
 }
 
-void mad_trk_xrotation_p (mflw_t *m, num_t lw) {
+void mad_trk_xrotation_p (mflw_t *m, num_t lw, int _) {
   xrotation<prm_t>(m->pflw, lw, zero);
 }
-void mad_trk_yrotation_p (mflw_t *m, num_t lw) {
+void mad_trk_yrotation_p (mflw_t *m, num_t lw, int _) {
   yrotation<prm_t>(m->pflw, lw, zero);
 }
-void mad_trk_srotation_p (mflw_t *m, num_t lw) {
+void mad_trk_srotation_p (mflw_t *m, num_t lw, int _) {
   srotation<prm_t>(m->pflw, lw, zero);
 }
-void mad_trk_translate_p (mflw_t *m, num_t lw) {
+void mad_trk_translate_p (mflw_t *m, num_t lw, int _) {
   translate<prm_t>(m->pflw, lw, zero, zero, zero);
 }
-void mad_trk_changeref_p (mflw_t *m, num_t lw) {
+void mad_trk_changeref_p (mflw_t *m, num_t lw, int _) {
   changeref<prm_t>(m->pflw, lw);
 }
 
 // --- misalignment ---
 
-void mad_trk_misalign_r (mflw_t *m, num_t lw) {
+void mad_trk_misalign_r (mflw_t *m, num_t lw, int _) {
   misalign<par_t>(m->rflw, lw);
 }
-void mad_trk_misalign_t (mflw_t *m, num_t lw) {
+void mad_trk_misalign_t (mflw_t *m, num_t lw, int _) {
   misalign<map_t>(m->tflw, lw);
 }
-void mad_trk_misalign_p (mflw_t *m, num_t lw) {
+void mad_trk_misalign_p (mflw_t *m, num_t lw, int _) {
   misalign<prm_t>(m->pflw, lw);
 }
 

--- a/src/mad_dynmap.cpp
+++ b/src/mad_dynmap.cpp
@@ -361,18 +361,19 @@ inline void changeref (cflw<M> &m, num_t lw)
   mdump(0);
   lw *= m.sdir;
 
+  // (y/x/s)rotation maps do lw*tdir, so to get the same result as in lua we muliply by sdir 
   if (rot && lw > 0) {
-    yrotation<M>(m,  m.edir, zero);
-    xrotation<M>(m, -m.edir, zero);
-    srotation<M>(m,  m.edir, zero);
+    yrotation<M>(m,  m.sdir, zero);
+    xrotation<M>(m, -m.sdir, zero);
+    srotation<M>(m,  m.sdir, zero);
   }
 
   if (trn) translate<M>(m, 1, zero, zero, zero);
 
   if (rot && lw < 0) {
-    srotation<M>(m, -m.edir, zero);
-    xrotation<M>(m,  m.edir, zero);
-    yrotation<M>(m, -m.edir, zero);
+    srotation<M>(m, -m.sdir, zero);
+    xrotation<M>(m,  m.sdir, zero);
+    yrotation<M>(m, -m.sdir, zero);
   }
   mdump(1);
 }

--- a/src/mad_dynmap.h
+++ b/src/mad_dynmap.h
@@ -39,28 +39,28 @@ void mad_trk_slice_tpt (mflw_t *m, num_t lw, trkfun *dft, trkfun *kck, int knd);
 void mad_trk_slice_one (mflw_t *m, num_t lw, trkfun *dft_or_kck);               // single
 
 // -- patches
-void mad_trk_xrotation_r    (mflw_t *m, num_t lw);
-void mad_trk_yrotation_r    (mflw_t *m, num_t lw);
-void mad_trk_srotation_r    (mflw_t *m, num_t lw);
-void mad_trk_translate_r    (mflw_t *m, num_t lw);
-void mad_trk_changeref_r    (mflw_t *m, num_t lw);
+void mad_trk_xrotation_r    (mflw_t *m, num_t lw, int _);
+void mad_trk_yrotation_r    (mflw_t *m, num_t lw, int _);
+void mad_trk_srotation_r    (mflw_t *m, num_t lw, int _);
+void mad_trk_translate_r    (mflw_t *m, num_t lw, int _);
+void mad_trk_changeref_r    (mflw_t *m, num_t lw, int _);
 
-void mad_trk_xrotation_t    (mflw_t *m, num_t lw);
-void mad_trk_yrotation_t    (mflw_t *m, num_t lw);
-void mad_trk_srotation_t    (mflw_t *m, num_t lw);
-void mad_trk_translate_t    (mflw_t *m, num_t lw);
-void mad_trk_changeref_t    (mflw_t *m, num_t lw);
+void mad_trk_xrotation_t    (mflw_t *m, num_t lw, int _);
+void mad_trk_yrotation_t    (mflw_t *m, num_t lw, int _);
+void mad_trk_srotation_t    (mflw_t *m, num_t lw, int _);
+void mad_trk_translate_t    (mflw_t *m, num_t lw, int _);
+void mad_trk_changeref_t    (mflw_t *m, num_t lw, int _);
 
-void mad_trk_xrotation_p    (mflw_t *m, num_t lw);
-void mad_trk_yrotation_p    (mflw_t *m, num_t lw);
-void mad_trk_srotation_p    (mflw_t *m, num_t lw);
-void mad_trk_translate_p    (mflw_t *m, num_t lw);
-void mad_trk_changeref_p    (mflw_t *m, num_t lw);
+void mad_trk_xrotation_p    (mflw_t *m, num_t lw, int _);
+void mad_trk_yrotation_p    (mflw_t *m, num_t lw, int _);
+void mad_trk_srotation_p    (mflw_t *m, num_t lw, int _);
+void mad_trk_translate_p    (mflw_t *m, num_t lw, int _);
+void mad_trk_changeref_p    (mflw_t *m, num_t lw, int _);
 
 // -- misalign
-void mad_trk_misalign_r     (mflw_t *m, num_t lw);
-void mad_trk_misalign_t     (mflw_t *m, num_t lw);
-void mad_trk_misalign_p     (mflw_t *m, num_t lw);
+void mad_trk_misalign_r     (mflw_t *m, num_t lw, int _);
+void mad_trk_misalign_t     (mflw_t *m, num_t lw, int _);
+void mad_trk_misalign_p     (mflw_t *m, num_t lw, int _);
 
 // -- fringe maps
 void mad_trk_strex_fringe_r (mflw_t *m, num_t lw);

--- a/src/madl_cmad.mad
+++ b/src/madl_cmad.mad
@@ -926,31 +926,31 @@ void mad_trk_slice_dkd (mflw_t *m, num_t lw, trkfun *dft, trkfun *kck, int ord);
 void mad_trk_slice_tkt (mflw_t *m, num_t lw, trkfun *dft, trkfun *kck, int ord);
 void mad_trk_slice_kmk (mflw_t *m, num_t lw, trkfun *dft, trkfun *kck, int ord);
 void mad_trk_slice_tpt (mflw_t *m, num_t lw, trkfun *dft, trkfun *kck, int knd);
-void mad_trk_slice_one (mflw_t *m, num_t lw, trkfun *dft);
+void mad_trk_slice_one (mflw_t *m, num_t lw, trkfun *dft_or_kck);
 
 // -- patches
-void mad_trk_xrotation_r    (mflw_t *m, num_t lw);
-void mad_trk_yrotation_r    (mflw_t *m, num_t lw);
-void mad_trk_srotation_r    (mflw_t *m, num_t lw);
-void mad_trk_translate_r    (mflw_t *m, num_t lw);
-void mad_trk_changeref_r    (mflw_t *m, num_t lw);
+void mad_trk_xrotation_r    (mflw_t *m, num_t lw, int _);
+void mad_trk_yrotation_r    (mflw_t *m, num_t lw, int _);
+void mad_trk_srotation_r    (mflw_t *m, num_t lw, int _);
+void mad_trk_translate_r    (mflw_t *m, num_t lw, int _);
+void mad_trk_changeref_r    (mflw_t *m, num_t lw, int _);
 
-void mad_trk_xrotation_t    (mflw_t *m, num_t lw);
-void mad_trk_yrotation_t    (mflw_t *m, num_t lw);
-void mad_trk_srotation_t    (mflw_t *m, num_t lw);
-void mad_trk_translate_t    (mflw_t *m, num_t lw);
-void mad_trk_changeref_t    (mflw_t *m, num_t lw);
+void mad_trk_xrotation_t    (mflw_t *m, num_t lw, int _);
+void mad_trk_yrotation_t    (mflw_t *m, num_t lw, int _);
+void mad_trk_srotation_t    (mflw_t *m, num_t lw, int _);
+void mad_trk_translate_t    (mflw_t *m, num_t lw, int _);
+void mad_trk_changeref_t    (mflw_t *m, num_t lw, int _);
 
-void mad_trk_xrotation_p    (mflw_t *m, num_t lw);
-void mad_trk_yrotation_p    (mflw_t *m, num_t lw);
-void mad_trk_srotation_p    (mflw_t *m, num_t lw);
-void mad_trk_translate_p    (mflw_t *m, num_t lw);
-void mad_trk_changeref_p    (mflw_t *m, num_t lw);
+void mad_trk_xrotation_p    (mflw_t *m, num_t lw, int _);
+void mad_trk_yrotation_p    (mflw_t *m, num_t lw, int _);
+void mad_trk_srotation_p    (mflw_t *m, num_t lw, int _);
+void mad_trk_translate_p    (mflw_t *m, num_t lw, int _);
+void mad_trk_changeref_p    (mflw_t *m, num_t lw, int _);
 
 // -- misalign
-void mad_trk_misalign_r     (mflw_t *m, num_t lw);
-void mad_trk_misalign_t     (mflw_t *m, num_t lw);
-void mad_trk_misalign_p     (mflw_t *m, num_t lw);
+void mad_trk_misalign_r     (mflw_t *m, num_t lw, int _);
+void mad_trk_misalign_t     (mflw_t *m, num_t lw, int _);
+void mad_trk_misalign_p     (mflw_t *m, num_t lw, int _);
 
 // -- fringe maps
 void mad_trk_strex_fringe_r (mflw_t *m, num_t lw);

--- a/src/madl_etrck.mad
+++ b/src/madl_etrck.mad
@@ -708,11 +708,17 @@ local function track_marker (elm, m)
   trackone(elm, m, thinonly, fnil)
 end
 
+local rot_angles = {
+  [yrotation] = "dthe",
+  [xrotation] = "dphi",
+  [srotation] = "dpsi",
+}
+
 local function track_rotation (elm, m, rot)
   m.ang = elm.angle
 
   if m.cmap then
-    m.cflw.ang = m.ang
+    m.cflw[rot_angles[rot]] = m.ang
   end
 
   trackone(elm, m, thinonly, rot)

--- a/src/madl_etrck.mad
+++ b/src/madl_etrck.mad
@@ -523,9 +523,8 @@ end
 
 local function crot (elm, m, dir)
   if m.cmap then
-    m.cflw.dpsi = m.tlt
+    m.cflw.dpsi = m.tlt*m.tdir -- dpsi is tilted in the cmap
     map[m.cmap][srotation](m.cflw_, dir, 0)
-    m.cflw.dpsi = 0
   else
     srotation(elm, m, dir, m.tlt)
   end

--- a/src/madl_etrck.mad
+++ b/src/madl_etrck.mad
@@ -523,10 +523,9 @@ end
 
 local function crot (elm, m, dir)
   if m.cmap then
-    m.cflw.tlt = m.tlt
-    map[m.cmap][srotation](m.cflw_, dir)
+    map[m.cmap][srotation](m.cflw_, dir, m.tlt)
   else
-    srotation(elm, m, dir)
+    srotation(elm, m, dir, m.tlt)
   end
 end
 

--- a/src/madl_etrck.mad
+++ b/src/madl_etrck.mad
@@ -523,7 +523,9 @@ end
 
 local function crot (elm, m, dir)
   if m.cmap then
-    map[m.cmap][srotation](m.cflw_, dir, m.tlt)
+    m.cflw.dpsi = m.tlt
+    map[m.cmap][srotation](m.cflw_, dir, 0)
+    m.cflw.dpsi = 0
   else
     srotation(elm, m, dir, m.tlt)
   end
@@ -531,7 +533,7 @@ end
 
 local function cmisalign (elm, m, dir)
   if m.cmap then
-    map[m.cmap][misalign](m.cflw_, dir)
+    map[m.cmap][misalign](m.cflw_, dir, 0)
   else
     misalign(elm, m, dir)
   end


### PR DESCRIPTION
An updated version of #367 with the comments taken into account

### Fixes List
- Make all patches follow trkfun format.
- Add third argument to patches so that they run in trackone
- Fix tilt so that srotation is performed in C and Lua
- ~Fix symmetry between Lua and C~
- ~Make Lua and C attitude to optional arguments and m.d(the/phi/psi) identical~
- ~Force tilt in Lua and C to work the same~
- Fix changeref weighting