### PR TITLE
Multipole Solenoid Fixes

### DIFF
--- a/src/mad_dynmap.cpp
+++ b/src/mad_dynmap.cpp
@@ -503,12 +503,12 @@ inline void strex_kick (cflw<M> &m, num_t lw, int is, bool no_k0l=false)
 template <typename M, typename T=M::T, typename P=M::P, typename R=M::R>
 inline void strex_kicks (cflw<M> &m, num_t lw, M &p, T &pz)
 {
-  if (fval(m.ks) < minstr || fval(m.lrad) < minlen) return;
+  if (fabs(m.ks) < minstr || fval(m.lrad) < minlen) return;
 
   num_t wchg = lw*m.sdir*m.edir*m.charge;
-  P hss  = lw*sqr(R(m.ks));
+  P hss  = lw*R(m.lrad)*sqr(R(m.ks));
   T _dpp = inv(pz);
-  T  ang = 0.5*wchg*R(m.ks)*R(m.lrad)*_dpp;
+  T  ang = (0.5*wchg)*R(m.ks)*R(m.lrad)*_dpp;
   T  ca  = cos(ang), sa = sin(ang);
 
   T nx  = ca*p. x + sa*p. y;
@@ -527,7 +527,7 @@ inline void strex_kicks (cflw<M> &m, num_t lw, M &p, T &pz)
 template <typename M, typename T=M::T, typename P=M::P, typename R=M::R>
 inline void strex_kickhs (cflw<M> &m, num_t lw, int is)
 {                                             (void)is;
-  if ((!m.nmul && fval(m.ks) < minstr) || !m.charge) return;
+  if ((!m.nmul && fabs(m.ks) < minstr) || !m.charge) return;
 
   mdump(0);
   num_t wchg = lw*m.sdir*m.edir*m.charge;

--- a/src/mad_dynmap.cpp
+++ b/src/mad_dynmap.cpp
@@ -503,9 +503,9 @@ inline void strex_kick (cflw<M> &m, num_t lw, int is, bool no_k0l=false)
 template <typename M, typename T=M::T, typename P=M::P, typename R=M::R>
 inline void strex_kicks (cflw<M> &m, num_t lw, M &p, T &pz)
 {
-  if (fabs(m.ks) < minstr || fval(m.lrad) < minlen) return;
+  if (fabs(m.ks) < minstr || fabs(m.lrad) < minlen) return;
 
-  num_t wchg = lw*m.sdir*m.edir*m.charge;
+  num_t wchg = lw*m.edir*m.charge; // lrad is already weighted by sdir
   P hss  = lw*R(m.lrad)*sqr(R(m.ks));
   T _dpp = inv(pz);
   T  ang = (0.5*wchg)*R(m.ks)*R(m.lrad)*_dpp;

--- a/src/madl_etrck.mad
+++ b/src/madl_etrck.mad
@@ -788,7 +788,7 @@ local function track_multipole (elm, m)
 
   if m.cmap and not m.pmap then
     m.cflw.lrad = m.lrad
-    m.cflw.ks   = m.ksi/m.lrad
+    m.cflw.ks   = m.ksi/lrad
     cpy_mult(m)
   end
 


### PR DESCRIPTION
- Force ks to use the lrad unweighted by sdir
- Change ks checks to be fabs and ks can be negative
- Multiply sqr(ks) by lrad
- Remove sdir from wchg as lrad takes this into account
- Change lrad check to be fabs for backtracking