### PR TITLE
Curved Kick Fixes

### DIFF
--- a/src/mad_dynmap.cpp
+++ b/src/mad_dynmap.cpp
@@ -223,14 +223,14 @@ inline void bxbyh (const cflw<M> &m, const V &x, const V &y, T &bx, T &by)
   RFOR(i,m.snm) {
     btx = 0., bty = 0.;
 
-    RFOR(j,m.snm-i) { ++k;
+    RFOR(j,m.snm-(i+1)) { ++k;
       btx = (btx + R(m.bfx[k])) * y;
       bty = (bty + R(m.bfy[k])) * y;
     }
 
     ++k;
-    btx = (bx + btx + R(m.bfx[k])) * x;
-    bty = (by + bty + R(m.bfy[k])) * x;
+    bx = (bx + btx + R(m.bfx[k])) * x;
+    by = (by + bty + R(m.bfy[k])) * x;
   }
 
   btx = 0., bty = 0.;
@@ -239,8 +239,8 @@ inline void bxbyh (const cflw<M> &m, const V &x, const V &y, T &bx, T &by)
     bty = (bty + R(m.bfy[k])) * y;
   }
 
-  bx += btx + R(m.bfx[k+1]);
-  by += bty + R(m.bfy[k+1]);
+  bx = bx + btx + R(m.bfx[k+1]); // Not using += reduces numerical instability with Lua 
+  by = by + bty + R(m.bfy[k+1]);
 }
 
 // --- patches ----------------------------------------------------------------o

--- a/src/madl_etrck.mad
+++ b/src/madl_etrck.mad
@@ -429,9 +429,11 @@ local function cpy_mult (m)
     c.ksl[i-1] = m.ksl[i]
   end
 
-  for i=1,c.snm do
-    c.bfx[i-1] = m.bfx[i]
-    c.bfy[i-1] = m.bfy[i]
+  if c.snm > 0 then -- bfx and bfy will have nil values otherwise
+    for i=1,(c.snm+1)*(c.snm+2)/2 do
+      c.bfx[i-1] = m.bfx[i] 
+      c.bfy[i-1] = m.bfy[i] 
+    end  
   end
 end
 


### PR DESCRIPTION
- Fix bf(x/y) copy to c. 
- Fix the loop of bxbyh in C++. 
- Reduce Lua vs Cpp numerical discrepancy in bxbyh