### PR TITLE
NgVsNg Improvements

### DIFF
--- a/tests/tests/test-convergence/test-convergence.mad
+++ b/tests/tests/test-convergence/test-convergence.mad
@@ -26,7 +26,7 @@ local ref_cfg = object "ref" {
   debug  = 0,        -- 0/6
   snm    = -1,
   seql   =  2,
-  cmap   = false,
+  cmap   = true,
 
   x0i    = 1..5,       -- 0, 4D, 5D, 5D strong, 6D (see get_mad_str)
 }

--- a/tests/tests/test-ng-maps/test-curved-maps.mad
+++ b/tests/tests/test-ng-maps/test-curved-maps.mad
@@ -79,7 +79,7 @@ function TestCurved:testQUADh() -- Test curvature in straight fringe
       quadrupole 'quadh' {
         at=0.75, l=1.5,  k0=${k0}*${bdir}, k1=${bdir}*0.5,
         e1=${tdir}*${e1}*math.pi/100*1.5, e2=${tdir}*${e2}*math.pi/100*1.5,
-        fringe=0, h1=${h1}, h2=${h2},
+        fringe=0
       }
     ]],
     model  = {1},
@@ -87,18 +87,42 @@ function TestCurved:testQUADh() -- Test curvature in straight fringe
     nslice = {1},
     energy = {1, 6500},  -- {1, 450, 6500}
 
-    tol = 750,! (h1, h2 = 0) otherwise, failure
+    tol = 750,
 
     k0 = {0, 1e-2},
     e1 = {-0.15, 0, 0.2},
     e2 = {-0.2, 0, 0.15},
-    h1 = {0,-0.04, 0.05}, ! This works with backtracking on 0 orbit only
-    h2 = {0, 0.04,-0.05}, ! This does not work with backtracking at all
-    alist = tblcat(ref_cfg.alist, {"k0", "e1", "e2", "h1", "h2"}),
+    alist = tblcat(ref_cfg.alist, {"k0", "e2", "e1"}),
     plot_info = {
       title    = "Straight Fringe With Curvature NG v NG Maps",
       filename = "quadh-ngvng.png",
     }  
+  }
+  run_test(cfg)
+end
+
+function TestCurved:testBENDFACE()
+  local cfg = ref_cfg "bend_face" {
+    elm = [[
+      quadrupole 'quad_bf' {
+        at=0.75, l=1.5,  k0=1e-2*${bdir}, k1=${bdir}*0.5,
+        h1=${h1}, h2=${h2}, fringe=0       
+      }
+    ]],
+    model  = {1},
+    method = {2},
+    nslice = {1},
+    energy = {1, 6500},  -- {1, 450, 6500}
+
+    tol = 100, 
+    
+    h1 = {0,-0.04, 0.05},
+    h2 = {0, 0.04,-0.05},
+    alist = tblcat(ref_cfg.alist, {"h1", "h2"}),
+    plot_info = {
+      title    = "Bend Face NG v NG Maps",
+      filename = "bendface-ngvng.png",
+    }
   }
   run_test(cfg)
 end

--- a/tests/tests/test-ng-maps/test-electric-maps.mad
+++ b/tests/tests/test-ng-maps/test-electric-maps.mad
@@ -21,7 +21,7 @@ end
 function TestElectric:testRFMULTIPOLE()
   local cfg = ref_cfg "rfmultipole" {
     elm = [[${element} 'rfm' {
-      at=0, l=0, volt=0, freq=1, mult_arr = ${knl},
+      at=0, l=0, volt=${volt}*${bdir}, freq=${freq}, lag=${lag}, mult_arr = ${knl},
       knl=\s -> {
         s.mult_arr[1] * ${bdir},
         s.mult_arr[2] * ${bdir},
@@ -49,7 +49,10 @@ function TestElectric:testRFMULTIPOLE()
       {0, 0, 0, 500},
       {0.5, 5, 50, 500},
     },
-    alist = tblcat(ref_cfg.alist, {"knl"}),
+    volt = {-8, 0, 8},
+    freq = {75, 150, 225},
+    lag  = {0, 0.8},
+    alist = tblcat(ref_cfg.alist, {"knl", "volt", "freq", "lag"}),
 
     plot_info = {
       title    = "RF-Multipole NG v NG Maps",

--- a/tests/tests/test-ng-maps/test-fringe-maps.mad
+++ b/tests/tests/test-ng-maps/test-fringe-maps.mad
@@ -18,7 +18,7 @@ function TestFringes:setUp()
 end
 
 function TestFringes:testSBENDf() -- Test the curved fringes
-  local cfg = ref_cfg "sbend" {
+  local cfg = ref_cfg "sbendf" {
     elm = [[sbend 'sbend' {
       at=0.75, l=1.5, 
       angle=${tdir}*math.pi/100*1.5, k0=${k0}*${bdir}*math.pi/100,
@@ -45,7 +45,7 @@ function TestFringes:testSBENDf() -- Test the curved fringes
     f2     = \s->s.cur_cfg.fringe > 4 and {0, 0.2} or {0},
     frngmax = {2, 5},
     k3    = \s-> s.cur_cfg.frngmax>2 and 10 or 0,
-    alist = tblcat(ref_cfg.alist, {"k1", "k1s", "k0", "fringe", "fint", "fintx", "hgap", "f1", "f2", "frngmax"}),
+    alist = tblcat(ref_cfg.alist, {"k0", "k1s", "k1", "fringe", "fint", "fintx", "hgap", "f1", "f2", "frngmax"}),
 
     plot_info = {
       title    = "Curved Fringe NG v NG Maps",
@@ -56,7 +56,7 @@ function TestFringes:testSBENDf() -- Test the curved fringes
 end
 
 function TestFringes:testQUADf() -- Test the straight fringes
-  local cfg = ref_cfg "quad" {
+  local cfg = ref_cfg "quadf" {
     elm = [[quadrupole 'quad' {
       at=0.75, l=1.5, 
       knl={${bdir}*${k0}, ${bdir}*${k1}, ${bdir}*${k2}}, 
@@ -69,8 +69,7 @@ function TestFringes:testQUADf() -- Test the straight fringes
     nslice = {1},
     energy = {1, 6500},  -- {1, 450, 6500}
 
-    tol = 400,
-    dobck = false, -- No backtracking, some fringes are not fully reversible
+    tol = 1e3,
 
     k1     = {0, -0.15, 0.2},
     k1s    = {0, -0.15, 0.2},

--- a/tests/tests/test-ng-maps/test-fringe-maps.mad
+++ b/tests/tests/test-ng-maps/test-fringe-maps.mad
@@ -75,7 +75,7 @@ function TestFringes:testQUADf() -- Test the straight fringes
     k1     = {0, -0.15, 0.2},
     k1s    = {0, -0.15, 0.2},
     k0     = {0, 1e-2},
-    fringe = {1, 6, 7},
+    fringe = {0, 1, 3, 6, 7},
     fint   = \s->s.cur_cfg.fringe%2==1 and {0, 0.5}   or {0},
     fintx  = \s->s.cur_cfg.fringe%2==1 and {0, 0.7}   or {0},
     hgap   = \s->s.cur_cfg.fringe%2==1 and {0, 0.05} or {0},
@@ -83,7 +83,7 @@ function TestFringes:testQUADf() -- Test the straight fringes
     f2     = \s->s.cur_cfg.fringe > 1 and {0, 0.2} or {0},
     frngmax = {2, 5},
     k2    = \s-> s.cur_cfg.frngmax>2 and 10 or 0,
-    alist = tblcat(ref_cfg.alist, {"k1", "k1s", "k0", "fringe", "fint", "fintx", "hgap", "f1", "f2", "frngmax"}),
+    alist = tblcat(ref_cfg.alist, {"k0", "k1s", "k1", "fringe", "fint", "fintx", "hgap", "f1", "f2", "frngmax"}),
 
     plot_info = {
       title    = "Straight Fringe NG v NG Maps",

--- a/tests/tests/test-ng-maps/test-misalignment-maps.mad
+++ b/tests/tests/test-ng-maps/test-misalignment-maps.mad
@@ -151,7 +151,7 @@ function TestMis:testSBENDrot()
 end
 
 function TestMis:testRBEND()
-  local cfg = ref_cfg "rbend" {
+  local cfg = ref_cfg "rbend_mis" {
     elm = [[
       rbend 'rbend' {
         at=0.75, l=1.5, k0=${k0}*${bdir}*math.pi/${angle_div}, angle=${tdir}*math.pi/${angle_div}*1.5, fringe=0,

--- a/tests/tests/test-ng-maps/trackvsng.mad
+++ b/tests/tests/test-ng-maps/trackvsng.mad
@@ -98,10 +98,15 @@ end
 
 local function do_unit_test(cfg, dif)
   if cfg.do_utest then
-    assertTrue(
-      chk_tol(dif, cfg.tol, cfg.order), 
-      tostring(dif) .. "test type: " .. cfg.cur_cfg.test_type
-    )
+    local test_result, out_string = chk_tol(dif, cfg.tol, cfg.order), ""
+    if not test_result then
+      out_string = "Tolerance needed to pass test: {" 
+      for i = 0, cfg.order do
+        out_string = out_string .. math.ceil(dif["order"..i.."_eps"])+1 .. ", "
+      end
+      out_string = out_string:sub(1, -3) .. "}" .. ", test type: " .. cfg.cur_cfg.test_type 
+    end
+    assertTrue(test_result, out_string)
   end
 end
 
@@ -178,7 +183,7 @@ end
 local function run_cfg(cfg, equiv, results)
   -- Get the mflow for the main config
   if not cfg.chk_cfg then -- If cfg is not in the list of cfgs to run, increment cfgid and return
-    cfg.cur_cfg.cfgid = cfg.cur_cfg.cfgid + 1
+    cfg.cur_cfg.cfgid = cfg.cur_cfg.cfgid + cfg.npar
     return 
   end 
   cfg.ref_script = create_run(cfg, cfg.cur_cfg)

--- a/tests/tests/test-ng-maps/trackvsng.mad
+++ b/tests/tests/test-ng-maps/trackvsng.mad
@@ -176,7 +176,7 @@ local function cmaps(cfg, results)
   backtrack   (cfg, results) -- Backtrack
   reverse_chg (cfg, results) -- Change sign of chg
   reverse_edir(cfg, results) -- Change sign of edir
-  cfg.cmap, cfg.ref_map, cfg.ref_script = false, lref_map, lref_script
+  cfg.cmap, cfg.ref_map, cfg.ref_script = not cfg.cmap, lref_map, lref_script
 end
 
   
@@ -259,7 +259,7 @@ local function run_test(cfg, equiv)
   cfg.chg  = 1 -- 1/-1 (charge)
   cfg.tdir = \s-> s.edir * s.sdir          -- tracking time direction
   cfg.bdir = \s-> s.edir * s.sdir * s.chg  -- tracking beam direction
-  cfg.cmap = false
+  cfg.cmap = true -- Change the default for the release 0.9.8
 
   args_to_cfg(cfg)
   cfg.chk_cfg = get_cfgs_to_run(cfg.cid)

--- a/tests/tests/test-plots/readme.md
+++ b/tests/tests/test-plots/readme.md
@@ -1,8 +1,9 @@
 Run the following to run everything successfully:
 ```bash
-../mad test-all-plots.mad -s --ptc --ng --cpp --conv -x Deca -x Elsep
+../mad test-all-plots.mad -s --ptc --ng --cpp --conv -x Deca -x Elsep -x Parallel
 ../mad test-all-plots.mad -s --ng --cpp --conv -p Deca
 ../mad test-all-plots.mad -s --ng --cpp --conv -p Elsep
+../mad test-all-plots.mad -s --ng --cpp --conv -p Parallel
 ```
 
 Reasons for the three commands:

--- a/tests/tests/test-plots/test-all-plots.mad
+++ b/tests/tests/test-plots/test-all-plots.mad
@@ -64,7 +64,7 @@ ref_cfg = MAD.object "ref" {
   debug  = 0,        -- 0/6
   snm    = -1,
   seql   =  2,
-  cmap   = false,
+  cmap   = true, -- Change the default for the release 0.9.8
 
   X0     = {x =-0.25, px = 0.15, y=0, py=0, t=0, pt=0},
 }

--- a/tests/tests/test-ptc-maps/test-elec-maps.mad
+++ b/tests/tests/test-ptc-maps/test-elec-maps.mad
@@ -29,7 +29,7 @@ local ref_cfg = object "ref" {
   debug  = 0,        -- 0/6
   snm    = -1,
   seql   =  2,
-  cmap   = false,
+  cmap   = true,
 
   x0i    = 1..5,       -- 0, 4D, 5D, 5D strong, 6D (see get_mad_str)
 }

--- a/tests/tests/test-ptc-maps/test-misalign-maps.mad
+++ b/tests/tests/test-ptc-maps/test-misalign-maps.mad
@@ -22,7 +22,7 @@ local ref_cfg = object "ref" {
   debug  = 0,        -- 0/6
   snm    = -1,
   seql   =  2,
-  cmap   = false,
+  cmap   = true,
 
   x0i    = 1..5,       -- 0, 4D, 5D, 5D strong, 6D (see get_mad_str)
 }

--- a/tests/tests/test-ptc-maps/test-misc-maps.mad
+++ b/tests/tests/test-ptc-maps/test-misc-maps.mad
@@ -27,7 +27,7 @@ local ref_cfg = object "ref" {
   debug  = 0,        -- 0/6
   snm    = -1,
   seql   =  2,
-  cmap   = false,
+  cmap   = true,
 
   x0i    = 1..5,       -- 0, 4D, 5D, 5D strong, 6D (see get_mad_str)
 }

--- a/tests/tests/test-ptc-maps/test-mult-maps.mad
+++ b/tests/tests/test-ptc-maps/test-mult-maps.mad
@@ -27,7 +27,7 @@ local ref_cfg = object "ref" {
   debug  = 0,        -- 0/6
   snm    = -1,
   seql   =  2,
-  cmap   = false,
+  cmap   = true,
 
   x0i    = 1..5,       -- 0, 4D, 5D, 6D (see get_mad_str)
 }

--- a/tests/tests/test-ptc-maps/test-octu-maps.mad
+++ b/tests/tests/test-ptc-maps/test-octu-maps.mad
@@ -27,7 +27,7 @@ local ref_cfg = object "ref" {
   debug  = 0,        -- 0/6
   snm    = -1,
   seql   =  2,
-  cmap   = false,
+  cmap   = true,
 
   x0i    = 1..5,       -- 0, 4D, 5D, 5D strong, 6D (see get_mad_str)
 }

--- a/tests/tests/test-ptc-maps/test-patch-maps.mad
+++ b/tests/tests/test-ptc-maps/test-patch-maps.mad
@@ -27,7 +27,7 @@ local ref_cfg = object "ref" {
   debug  = 0,        -- 0/6
   snm    = -1,
   seql   =  2,
-  cmap   = false,
+  cmap   = true,
 
   x0i    = 1..5,       -- 0, 4D, 5D, 5D strong, 6D (see get_mad_str)
 }

--- a/tests/tests/test-ptc-maps/test-quad-maps.mad
+++ b/tests/tests/test-ptc-maps/test-quad-maps.mad
@@ -27,7 +27,7 @@ local ref_cfg = object "ref" {
   debug  = 0,        -- 0/6
   snm    = -1,
   seql   =  2,
-  cmap   = false,
+  cmap   = true,
 
   x0i    = 1..5,       -- 0, 4D, 5D, 6D (see get_mad_str)
 }

--- a/tests/tests/test-ptc-maps/test-rbend-maps.mad
+++ b/tests/tests/test-ptc-maps/test-rbend-maps.mad
@@ -27,7 +27,7 @@ local ref_cfg = object "ref" {
   debug  = 0,        -- 0/6
   snm    = -1,
   seql   =  2,
-  cmap   = false,
+  cmap   = true,
 
   x0i    = 1..5,       -- 0, 4D, 5D, 5D strong, 6D (see get_mad_str)
 }

--- a/tests/tests/test-ptc-maps/test-sbend-maps.mad
+++ b/tests/tests/test-ptc-maps/test-sbend-maps.mad
@@ -90,7 +90,6 @@ function TestSBend:testSBENDfr()
     ]],
 
     tol = 200,
-    cid = {id1, id2},
 
     model  = {2},
     method = {2},    

--- a/tests/tests/test-ptc-maps/test-sbend-maps.mad
+++ b/tests/tests/test-ptc-maps/test-sbend-maps.mad
@@ -27,7 +27,7 @@ local ref_cfg = object "ref_cfg" {
   debug  = 0,        -- 0/6
   snm    = -1,
   seql   =  2,
-  cmap   = false,
+  cmap   = true,
 
   x0i    = 1..5,       -- 0, 4D, 5D, 6D (see get_mad_str)
 }

--- a/tests/tests/test-ptc-maps/test-sext-maps.mad
+++ b/tests/tests/test-ptc-maps/test-sext-maps.mad
@@ -27,7 +27,7 @@ local ref_cfg = object "ref" {
   debug  = 0,        -- 0/6
   snm    = -1,
   seql   =  2,
-  cmap   = false,
+  cmap   = true,
 
   x0i    = 1..5,       -- 0, 4D, 5D, 5D strong, 6D (see get_mad_str)
 }

--- a/tests/tests/test-ptc-maps/test-solen-maps.mad
+++ b/tests/tests/test-ptc-maps/test-solen-maps.mad
@@ -27,7 +27,7 @@ local ref_cfg = object "ref" {
   debug  = 0,        -- 0/6
   snm    = -1,
   seql   =  2,
-  cmap   = false,
+  cmap   = true,
 
   x0i    = 1..5,       -- 0, 4D, 5D, 5D strong, 6D (see get_mad_str)
 }

--- a/tests/tests/test-ptc-maps/trackvsptc.mad
+++ b/tests/tests/test-ptc-maps/trackvsptc.mad
@@ -3,7 +3,7 @@ local mtable, object, damap, tostring                            in MAD
 local openfile, fileexists, tblcat, strinter                     in MAD.utility
 local is_table, is_iterable, is_number                           in MAD.typeid
 local assertTrue                                                 in MAD.utest
-local max                                                        in math         
+local max                                                        in math
 local eps                                                        in MAD.constant    
 
 package.path = package.path .. ";../tools/?.mad"

--- a/tests/tests/tools/test-tool.mad
+++ b/tests/tests/tools/test-tool.mad
@@ -63,7 +63,7 @@ local args_dict = { -- Do opposite to default
 -- Some test specific tables
 local patterns, excludes, tests_to_run = {}, {}, {__RUN_ALL__ = true}
 
-local global_cfg   = {dorun = true}
+local global_cfg   = {dorun = true, cmap=true} ---- Change the default for the release 0.9.8
 local mad_args     = tblcpy(MAD.env.arg) -- Copy the arg list for manipulation
 
 local args_to_cfg = \cfg => for k, v in pairs(global_cfg) do cfg[k] = v end end
@@ -138,7 +138,7 @@ local function parse_cmd_args(is_unittest) -- Parse the command line arguments
         arg_fun[arg](i, is_unittest) 
         remove_arg(is_unittest, i, arg)
       elseif arg then
-        -- If the argument is a known cfg boolean, set it (True for all but norun (sets dorun to false))
+        -- If the argument is a known cfg boolean, set it (True for all but norun and cmap (sets dorun and cmap to false))
         global_cfg[arg] = not global_cfg[arg]
 
         -- For compatibility with unittests, remove the arg from the arg list, except for verbose option


### PR DESCRIPTION
- Separate out h1, h2 to a different test
- Improve rfmult tests
- rename rbend misalignement test
- Improve fringe testing
- Improve output of errors on test failure (Now just a copy and paste)
- Improve cid for ng vs ng to work when performing a single test.
- Change default cmap to true