### PR TITLE
mad_mem realloc fails without assert triggering

### DIFF
--- a/src/mad_mem.c
+++ b/src/mad_mem.c
@@ -212,7 +212,11 @@ void*
   ensure(mbp->mark == MARK, "invalid or corrupted allocated memory");
 
   size_t idx = (size-1) / stp_slot;
-  mbp = realloc(mbp, SIZE(idx)); assert(mbp);
+  mbp = realloc(mbp, SIZE(idx));
+  assert(mbp); // check if it propagates beyond that assert
+               // could it be it gets removed during some
+               // "build process using optimisation"
+  ensure(mbp, "reallocation of main base ptr failed");
 
 #if MAD_MEM_CLR
   if (mbp->slot < idx && idx < max_slot) {


### PR DESCRIPTION
The "mad_desc" objects stores precomputed coefficients. Memory buffers are allocated as required. 
Allocation fails on my test machine for the program given below. 

If an "optimised" build is made, the assert will not stop the program, but ensure does.

This issue can be reproduced by the test program below (please increase `np` if it works on  your machine).

Test program

```c
#include <mad_desc.h>
#include <assert.h>
#include <stdio.h>

int main(void)
{
    const int nv=6, np=144;
    const ord_t mo=7, po=2;

    const desc_t* d = mad_desc_newvp (nv, mo, np, po);
    assert(d);
    mad_desc_info(d, NULL);

}
```
The output given is then 

```
error:  mad-ng/src/mad_mem.c:219: : reallocation of main base ptr failed
```


