### PR TITLE
Extended rms beamsize calculation

### DIFF
--- a/src/madl_gphys.mad
+++ b/src/madl_gphys.mad
@@ -1960,27 +1960,46 @@ local function is_ord_even (m)
   return true
 end
 
-function gphys.beamsize(x, sig)
+function gphys.beamsize(x, sig, mo)
   assert(is_tpsa(x), "invalid argument #1 (real TPSA expected)")
   assert(is_indexable(sig) and #sig >= 5,
                      "invalid argument #2 (iterable with 5+ values expected")
-  local nv, xs = x:nv(), 0
+  mo = mo or x.mo
+  assert(is_number(mo) and mo <= x.mo, "invalid argument #3 (order must not exceed TPSA order")
+
+  local nv, xs_4, xs_5 = x:nv(), 0, 0
   local mi, mj, mm = monomial(nv), monomial(nv), monomial(nv)
 
   for i,xi in x:iter(mi)   do
   for j,xj in x:iter(mj,i) do
-    if mj >= mi and is_ord_even(mi:add(mj,mm)) then
+    if mj >= mi and is_ord_even(mi:add(mj,mm)) and mj:ord() <= mo and mi:ord() <= mo then
+
       local sk, xx = 0, (i == j and 1 or 2)*xi*xj
       for k=1,4 do
         xx = xx * sig[k]^mm[k] * tgamma((1+mm[k])/2)
         sk = sk + mm[k]
       end
+
       xx = xx * sig[5]^mm[6] * 2^(sk/2-mm[6]) / ((1+mm[6])*pi^2)
-      xs = xs + xx
+
+      xs_4 = xs_4 + (mm[6] == 0 and xx or 0)
+      xs_5 = xs_5 + xx
     end
   end end
+    
+  return sqrt(xs_4), sqrt(xs_5)
+end
 
-  return sqrt(xs)
+function gphys.beamsize_oo(x, sig)
+  assert(is_tpsa(x), "invalid argument #1 (real TPSA expected)")
+  assert(is_indexable(sig) and #sig >= 5,
+                     "invalid argument #2 (iterable with 5+ values expected")
+  local sg, sd = {}, {} 
+  for i=1,x.mo do
+    sg[i], sd[i] = gphys.beamsize(x, sig, i)
+  end
+
+  return sg, sd
 end
 
 -- env ------------------------------------------------------------------------o

--- a/src/madl_gphys.mad
+++ b/src/madl_gphys.mad
@@ -29,7 +29,7 @@ local assert, table, type in _G
 local min, max in math
 
 local vector, cvector, matrix, monomial, damap, cdamap,
-      trace, warn, option, typeid, range                         in MAD
+      trace, warn, option, typeid, range, mtable                 in MAD
 local assertf, errorf, printf, num2str, tbl2str, setkeys, tblcat,
       mockfile, openfile                                         in MAD.utility
 local lbool                                                      in MAD.gfunc
@@ -2001,6 +2001,38 @@ function gphys.beamsize_oo(x, sig)
 
   return sg, sd
 end
+
+function gphys.beamsize_tbl(x, sig, momenta)
+  assert(is_damap(x), "invalid argument #1 (damap expected)")
+  assert(is_indexable(sig) and #sig >= 5,
+                     "invalid argument #2 (iterable with 5+ values expected")
+
+  local sg_x, sd_x = gphys.beamsize_oo(x[1], sig)
+  local sg_y, sd_y = gphys.beamsize_oo(x[3], sig)
+  local sg_px, sd_px, sg_py, sd_py
+  if momenta then
+    sg_px, sd_px = gphys.beamsize_oo(x[2], sig)
+    sg_py, sd_py = gphys.beamsize_oo(x[4], sig)
+  end
+
+  local tbl = MAD.mtable "rms beamsize" {{"order"}} -- why MAD.mtable is required, local mtable in MAD does not suffice?
+  for i=1,#sg_x do
+    tbl = tbl + {i} 
+  end 
+  tbl.type = sig
+
+  tbl:inscol("x_geo", sg_x)
+  tbl:inscol("x_tot", sd_x)
+  if momenta then tbl:inscol("px_geo", sg_px) end 
+  if momenta then tbl:inscol("px_tot", sd_px) end 
+  tbl:inscol("y_geo", sg_y)
+  tbl:inscol("y_tot", sd_y)
+  if momenta then tbl:inscol("py_geo", sg_py) end 
+  if momenta then tbl:inscol("py_tot", sd_py) end 
+
+  return tbl 
+end
+
 
 -- env ------------------------------------------------------------------------o
 


### PR DESCRIPTION
Extended rms beamsize calculation by an estimate for geometric abberations only.
Added a parameter to specify the highest map order to be taken into account.
Added a convenience function to return geometric and dispersive beamsize order-by-order.